### PR TITLE
fix: normalize `AbiFallback.inputs` type between `abitype` and `zod`

### DIFF
--- a/.changeset/angry-taxis-enjoy.md
+++ b/.changeset/angry-taxis-enjoy.md
@@ -1,0 +1,5 @@
+---
+"abitype": patch
+---
+
+normalize AbiFallback.inputs type and zod

--- a/packages/abitype/src/abi.ts
+++ b/packages/abitype/src/abi.ts
@@ -163,7 +163,7 @@ export type AbiConstructor = {
 /** ABI ["fallback"](https://docs.soliditylang.org/en/latest/abi-spec.html#json) type */
 export type AbiFallback = {
   type: 'fallback'
-  inputs?: readonly [] | undefined
+  inputs?: readonly never[] | undefined
   /**
    * @deprecated use `payable` or `nonpayable` from {@link AbiStateMutability} instead
    * @see https://github.com/ethereum/solidity/issues/992

--- a/packages/abitype/src/zod.test-d.ts
+++ b/packages/abitype/src/zod.test-d.ts
@@ -5,18 +5,23 @@ import type {
   AbiConstructor,
   AbiError,
   AbiEvent,
+  AbiFallback,
+  AbiFunction,
   AbiParameter,
 } from './abi.js'
 import {
   customSolidityErrorsAbi,
   ensRegistryWithFallbackAbi,
   erc20Abi,
+  wethAbi,
 } from './abis/json.js'
 import {
   Abi as AbiSchema,
   AbiConstructor as AbiConstructorSchema,
   AbiError as AbiErrorSchema,
   AbiEvent as AbiEventSchema,
+  AbiFallback as AbiFallbackSchema,
+  AbiFunction as AbiFunctionSchema,
   AbiParameter as AbiParameterSchema,
 } from './zod.js'
 
@@ -83,6 +88,54 @@ describe('Zod Types', () => {
     test('extends AbiEvent', () => {
       const parsed = AbiEventSchema.parse(approvalEvent)
       type Result = typeof parsed extends AbiEvent ? true : false
+      expectTypeOf<Result>().toEqualTypeOf<true>()
+    })
+  })
+
+  describe('AbiFunction', () => {
+    const approveFunction = erc20Abi[3]
+
+    test('assignable to AbiFunction', () => {
+      const parsed: AbiFunction = AbiFunctionSchema.parse(approveFunction)
+      type Result = typeof parsed extends AbiFunction ? true : false
+      expectTypeOf<Result>().toEqualTypeOf<true>()
+    })
+
+    test('extends AbiFunction', () => {
+      const parsed = AbiFunctionSchema.parse(approveFunction)
+      type Result = typeof parsed extends AbiFunction ? true : false
+      expectTypeOf<Result>().toEqualTypeOf<true>()
+    })
+  })
+
+  describe('AbiFallback', () => {
+    const approveFunction = wethAbi[11]
+
+    test('assignable to AbiFallback', () => {
+      const parsed: AbiFallback = AbiFallbackSchema.parse(approveFunction)
+      type Result = typeof parsed extends AbiFallback ? true : false
+      expectTypeOf<Result>().toEqualTypeOf<true>()
+    })
+
+    test('extends AbiFallback', () => {
+      const parsed = AbiFallbackSchema.parse(approveFunction)
+      type Result = typeof parsed extends AbiFallback ? true : false
+      expectTypeOf<Result>().toEqualTypeOf<true>()
+    })
+  })
+
+  describe('AbiFunction', () => {
+    const approveFunction = erc20Abi[3]
+
+    test('assignable to AbiFunction', () => {
+      const parsed: AbiFunction = AbiFunctionSchema.parse(approveFunction)
+      type Result = typeof parsed extends AbiFunction ? true : false
+      expectTypeOf<Result>().toEqualTypeOf<true>()
+    })
+
+    test('extends AbiFunction', () => {
+      const parsed = AbiFunctionSchema.parse(approveFunction)
+      type Result = typeof parsed extends AbiFunction ? true : false
       expectTypeOf<Result>().toEqualTypeOf<true>()
     })
   })

--- a/packages/abitype/src/zod.ts
+++ b/packages/abitype/src/zod.ts
@@ -164,7 +164,7 @@ export const AbiFallback = z.preprocess(
      * @deprecated use `pure` or `view` from {@link AbiStateMutability} instead
      * https://github.com/ethereum/solidity/issues/992
      */
-    inputs: z.tuple([]).optional(),
+    inputs: z.tuple([]).readonly().optional(),
     /**
      * @deprecated use `payable` or `nonpayable` from {@link AbiStateMutability} instead
      * https://github.com/ethereum/solidity/issues/992


### PR DESCRIPTION
## Description

This PR aligns the following `AbiFallback.inputs` type between Zod schema and `abitype`

```ts
type Left = AbiFallback['inputs']; // readonly []
type Right = z.infer<typeof AbiFallbackSchema>['inputs']; // never[]
```

After:


```ts
type Left = AbiFallback['inputs']; // readonly never[]
type Right = z.infer<typeof AbiFallbackSchema>['inputs']; readonly never[]
```


## Additional Information

Before submitting this issue, please make sure you do the following.

- [X] Read the [contributing guide](https://github.com/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md)
- [X] Added documentation related to the changes made.
- [X] Added or updated tests (and snapshots) related to the changes made.


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on normalizing the `AbiFallback.inputs` type and `zod`.

### Detailed summary:
- Normalize `AbiFallback.inputs` type and `zod`
- Update `packages/abitype/src/abi.ts` to use `readonly never[]` instead of `readonly []` for `AbiFallback.inputs`
- Update `packages/abitype/src/zod.ts` to use `z.tuple([]).readonly().optional()` for `AbiFallback.inputs`
- Add `AbiFallback` and `AbiFunction` to `packages/abitype/src/zod.test-d.ts`
- Update imports in `packages/abitype/src/zod.test-d.ts`
- Add tests for `AbiFunction` and `AbiFallback` in `packages/abitype/src/zod.test-d.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->