### PR TITLE
fix: typos

### DIFF
--- a/.changeset/twenty-olives-deliver.md
+++ b/.changeset/twenty-olives-deliver.md
@@ -2,4 +2,4 @@
 "abitype": patch
 ---
 
-Fix typos
+Fixed typos

--- a/packages/abitype/src/human-readable/errors/abiItem.test.ts
+++ b/packages/abitype/src/human-readable/errors/abiItem.test.ts
@@ -8,12 +8,12 @@ import {
 
 test('InvalidAbiItemError', () => {
   expect(
-    new InvalidAbiItemError({ signature: 'addres' }),
+    new InvalidAbiItemError({ signature: 'address' }),
   ).toMatchInlineSnapshot(`
     [InvalidAbiItemError: Failed to parse ABI item.
 
     Docs: https://abitype.dev/api/human.html#parseabiitem-1
-    Details: parseAbiItem("addres")
+    Details: parseAbiItem("address")
     Version: abitype@x.y.z]
   `)
 })

--- a/packages/abitype/src/human-readable/errors/abiParameter.test.ts
+++ b/packages/abitype/src/human-readable/errors/abiParameter.test.ts
@@ -12,24 +12,24 @@ import {
 
 test('InvalidAbiParamterError', () => {
   expect(
-    new InvalidAbiParameterError({ param: 'addres owner' }),
+    new InvalidAbiParameterError({ param: 'address owner' }),
   ).toMatchInlineSnapshot(`
     [InvalidAbiParameterError: Failed to parse ABI parameter.
 
     Docs: https://abitype.dev/api/human.html#parseabiparameter-1
-    Details: parseAbiParameter("addres owner")
+    Details: parseAbiParameter("address owner")
     Version: abitype@x.y.z]
   `)
 })
 
 test('InvalidAbiParamtersError', () => {
   expect(
-    new InvalidAbiParametersError({ params: 'addres owner' }),
+    new InvalidAbiParametersError({ params: 'address owner' }),
   ).toMatchInlineSnapshot(`
     [InvalidAbiParametersError: Failed to parse ABI parameters.
 
     Docs: https://abitype.dev/api/human.html#parseabiparameters-1
-    Details: parseAbiParameters("addres owner")
+    Details: parseAbiParameters("address owner")
     Version: abitype@x.y.z]
   `)
 })
@@ -37,12 +37,12 @@ test('InvalidAbiParamtersError', () => {
 test('InvalidParameterError', () => {
   expect(
     new InvalidParameterError({
-      param: 'addres',
+      param: 'address',
     }),
   ).toMatchInlineSnapshot(`
     [InvalidParameterError: Invalid ABI parameter.
 
-    Details: addres
+    Details: address
     Version: abitype@x.y.z]
   `)
 })
@@ -115,7 +115,7 @@ test('InvalidFunctionModifierError', () => {
 test('InvalidAbiTypeParameterError', () => {
   expect(
     new InvalidAbiTypeParameterError({
-      abiParameter: { type: 'addres' },
+      abiParameter: { type: 'address' },
     }),
   ).toMatchInlineSnapshot(`
     [InvalidAbiTypeParameterError: Invalid ABI parameter.
@@ -123,7 +123,7 @@ test('InvalidAbiTypeParameterError', () => {
     ABI parameter type is invalid.
 
     Details: {
-      "type": "addres"
+      "type": "address"
     }
     Version: abitype@x.y.z]
   `)

--- a/tidy-parrots-begin.md
+++ b/tidy-parrots-begin.md
@@ -1,0 +1,5 @@
+---
+"abitype": patch
+---
+
+Fix typos


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing typos in the `abitype` package. 

### Detailed summary:
- Fixed typos in error messages for `InvalidAbiItemError`, `InvalidAbiParameterError`, `InvalidAbiParametersError`, `InvalidParameterError`, `InvalidFunctionModifierError`, and `InvalidAbiTypeParameterError`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->