### PR TITLE
playground: ethers example implementation

### DIFF
--- a/.changeset/thirty-experts-listen.md
+++ b/.changeset/thirty-experts-listen.md
@@ -1,0 +1,5 @@
+---
+"abitype": patch
+---
+
+Adds a playground example of using `abitype` with ethers.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -60,3 +60,4 @@ After setting up your project with ABIType, you are ready to dive in further! He
 - Follow along with a [walkthrough](/guide/walkthrough) on building a type-safe `readContract` function.
 - Check out comparisons between features in [ABIType and TypeChain](/guide/comparisons#typechain) as well as [ABIType and ethers.js](/guide/comparisons#ethers-js).
 - Make reading and writing ABIs more human with [human-readable ABI support](/api/human).
+- Checkout our own [playground](https://github.com/wevm/abitype/tree/main/playgrounds/functions/src) full of examples on how to apply it on your projects. Including creating a wrapper for ethers contracts.

--- a/playgrounds/functions/package.json
+++ b/playgrounds/functions/package.json
@@ -7,5 +7,8 @@
   },
   "dependencies": {
     "abitype": "workspace:*"
+  },
+  "devDependencies": {
+    "ethers": "^6.5.1"
   }
 }

--- a/playgrounds/functions/src/ethers.test-d.ts
+++ b/playgrounds/functions/src/ethers.test-d.ts
@@ -1,0 +1,104 @@
+import type { ExtractAbiEvent, ResolvedRegister } from 'abitype'
+import type { ContractTransaction } from 'ethers'
+import type { CallOverrides, Event, Overrides } from './utils.js'
+
+import { wagmiMintExampleAbi } from 'abitype/abis'
+import { assertType, describe, expectTypeOf } from 'vitest'
+import { getContract } from './ethers.js'
+
+describe('getContract', () => {
+  const contract = getContract({
+    address: '0xfoo',
+    abi: wagmiMintExampleAbi,
+  })
+
+  describe('regular function', () => {
+    expectTypeOf(contract.balanceOf).toBeCallableWith('0x…', { from: '0x…' })
+    expectTypeOf(contract.balanceOf)
+      .parameter(0)
+      .toEqualTypeOf<ResolvedRegister['AddressType']>()
+    expectTypeOf(contract.balanceOf)
+      .parameter(1)
+      .toEqualTypeOf<CallOverrides | undefined>()
+    expectTypeOf(contract.balanceOf).returns.resolves.toEqualTypeOf<bigint>()
+
+    expectTypeOf(contract.functions.balanceOf).toBeCallableWith('0x…', {
+      from: '0x…',
+    })
+    expectTypeOf(contract.functions.balanceOf)
+      .parameter(0)
+      .toEqualTypeOf<ResolvedRegister['AddressType']>()
+    expectTypeOf(contract.functions.balanceOf)
+      .parameter(1)
+      .toEqualTypeOf<CallOverrides | undefined>()
+    expectTypeOf(contract.functions.balanceOf).returns.resolves.toEqualTypeOf<
+      [bigint]
+    >()
+  })
+
+  describe('overloaded function', () => {
+    const functionNameA = 'safeTransferFrom(address,address,uint256)'
+    expectTypeOf(contract[functionNameA]).toBeCallableWith(
+      '0x…',
+      '0x…',
+      BigInt('123'),
+      { from: '0x…' },
+    )
+    expectTypeOf(contract[functionNameA])
+      .parameter(0)
+      .toEqualTypeOf<ResolvedRegister['AddressType']>()
+    expectTypeOf(contract[functionNameA])
+      .parameter(1)
+      .toEqualTypeOf<ResolvedRegister['AddressType']>()
+    expectTypeOf(contract[functionNameA])
+      .parameter(2)
+      .toEqualTypeOf<ResolvedRegister['BigIntType']>()
+    expectTypeOf(contract[functionNameA])
+      .parameter(3)
+      .toEqualTypeOf<
+        (Overrides & { from?: `0x${string}` | undefined }) | undefined
+      >()
+    expectTypeOf(
+      contract[functionNameA],
+    ).returns.resolves.toEqualTypeOf<ContractTransaction>()
+
+    const functionNameB = 'safeTransferFrom(address,address,uint256,bytes)'
+    expectTypeOf(contract[functionNameB]).toBeCallableWith(
+      '0x…',
+      '0x…',
+      BigInt('123'),
+      '0x…',
+      { from: '0x…' },
+    )
+    expectTypeOf(contract[functionNameB])
+      .parameter(0)
+      .toEqualTypeOf<ResolvedRegister['AddressType']>()
+    expectTypeOf(contract[functionNameB])
+      .parameter(1)
+      .toEqualTypeOf<ResolvedRegister['AddressType']>()
+    expectTypeOf(contract[functionNameB])
+      .parameter(2)
+      .toEqualTypeOf<ResolvedRegister['BigIntType']>()
+    expectTypeOf(contract[functionNameB])
+      .parameter(3)
+      .toEqualTypeOf<ResolvedRegister['BytesType']['inputs']>()
+    expectTypeOf(contract[functionNameB])
+      .parameter(4)
+      .toEqualTypeOf<
+        (Overrides & { from?: `0x${string}` | undefined }) | undefined
+      >()
+    expectTypeOf(
+      contract[functionNameB],
+    ).returns.resolves.toEqualTypeOf<ContractTransaction>()
+  })
+
+  // Events
+  contract.on('Transfer', (from, to, value, event) => {
+    assertType<ResolvedRegister['AddressType']>(from)
+    assertType<ResolvedRegister['AddressType']>(to)
+    assertType<ResolvedRegister['BigIntType']>(value)
+    assertType<
+      Event<ExtractAbiEvent<typeof wagmiMintExampleAbi, 'Transfer'>>
+    >(event)
+  })
+})

--- a/playgrounds/functions/src/ethers.ts
+++ b/playgrounds/functions/src/ethers.ts
@@ -1,0 +1,313 @@
+import type {
+  Abi,
+  AbiEvent,
+  AbiFunction,
+  AbiParameter,
+  AbiParameterToPrimitiveType,
+  AbiParametersToPrimitiveTypes,
+  Address,
+  ExtractAbiEvent,
+  ExtractAbiEventNames,
+  ResolvedRegister,
+} from 'abitype'
+
+import type {
+  ContractInterface,
+  ContractTransaction,
+  EventFilter,
+  EventLog,
+  FunctionFragment,
+  InterfaceAbi,
+  Provider,
+  Signer,
+} from 'ethers'
+
+import { Contract as EthersContract } from 'ethers'
+
+import type { IsUnknown, UnionToIntersection } from './types.js'
+import type {
+  AbiItemName,
+  CountOccurrences,
+  Event,
+  GetOverridesForAbiStateMutability,
+} from './utils.js'
+
+export function getContract<const abi extends Abi | readonly unknown[]>({
+  address,
+  abi,
+  signerOrProvider,
+}: GetContractArgs<abi>): GetContractResult<abi> {
+  return new EthersContract(
+    address,
+    abi as unknown as InterfaceAbi,
+    signerOrProvider,
+  ) as GetContractResult<abi>
+}
+
+export type GetContractResult<TAbi = unknown> = TAbi extends Abi
+  ? Contract<TAbi> & EthersContract
+  : EthersContract
+
+export type GetContractArgs<abi extends Abi | readonly unknown[]> = {
+  address: Address
+
+  abi: abi
+
+  signerOrProvider?: Signer | Provider
+}
+
+type PropertyKeys =
+  | 'address'
+  | 'attach'
+  | 'connect'
+  | 'deployed'
+  | 'interface'
+  | 'resolvedAddress'
+type FunctionKeys =
+  | 'callStatic'
+  | 'estimateGas'
+  | 'functions'
+  | 'populateTransaction'
+type EventKeys =
+  | 'emit'
+  | 'filters'
+  | 'listenerCount'
+  | 'listeners'
+  | 'off'
+  | 'on'
+  | 'once'
+  | 'queryFilter'
+  | 'removeAllListeners'
+  | 'removeListener'
+
+type BaseContract<
+  TContract extends Record<
+    keyof Pick<EthersContract, PropertyKeys | FunctionKeys | EventKeys>,
+    unknown
+  >,
+> = Omit<EthersContract, PropertyKeys | FunctionKeys | EventKeys> & TContract
+
+type InterfaceKeys = 'events' | 'functions'
+// Create new `Interface` and remove keys we are going to type
+type BaseInterface<
+  Interface extends Record<
+    keyof Pick<ContractInterface, InterfaceKeys>,
+    unknown
+  >,
+> = Omit<ContractInterface, InterfaceKeys> & Interface
+
+type Contract<TAbi extends Abi, _Functions = Functions<TAbi>> = _Functions &
+  BaseContract<{
+    address: Address
+    resolvedAddress: Promise<Address>
+    attach(addressOrName: Address | string): Contract<TAbi>
+    connect(signerOrProvider: Signer | Provider | string): Contract<TAbi>
+    deployed(): Promise<Contract<TAbi>>
+    interface: BaseInterface<{
+      events: InterfaceEvents<TAbi>
+      functions: InterfaceFunctions<TAbi>
+    }>
+
+    callStatic: _Functions
+    estimateGas: Functions<TAbi, { ReturnType: ResolvedRegister['BigIntType'] }>
+    functions: Functions<TAbi, { ReturnTypeAsArray: true }>
+    populateTransaction: Functions<TAbi, { ReturnType: ContractTransaction }>
+
+    emit<TEventName extends ExtractAbiEventNames<TAbi> | EventFilter>(
+      eventName: TEventName,
+      ...args: AbiParametersToPrimitiveTypes<
+        ExtractAbiEvent<
+          TAbi,
+          TEventName extends string ? TEventName : ExtractAbiEventNames<TAbi>
+        >['inputs']
+      > extends infer TArgs extends readonly unknown[]
+        ? TArgs
+        : never
+    ): boolean
+    filters: Filters<TAbi>
+    listenerCount(): number
+    listenerCount<TEventName extends ExtractAbiEventNames<TAbi>>(
+      eventName: TEventName,
+    ): number
+    // TODO: Improve `eventFilter` type
+    listenerCount(eventFilter: EventFilter): number
+    listeners(): Array<(...args: any[]) => void>
+    listeners<TEventName extends ExtractAbiEventNames<TAbi>>(
+      eventName: TEventName,
+    ): Listener<TAbi, TEventName>[]
+    listeners(
+      // TODO: Improve `eventFilter` and return types
+      eventFilter: EventFilter,
+    ): Listener<TAbi, ExtractAbiEventNames<TAbi>>[]
+    off: EventListener<TAbi>
+    on: EventListener<TAbi>
+    once: EventListener<TAbi>
+    queryFilter<TEventName extends ExtractAbiEventNames<TAbi>>(
+      event: TEventName,
+      fromBlockOrBlockhash?: string | number,
+      toBlock?: string | number,
+    ): Promise<EventLog[]>
+    // TODO: Improve `eventFilter` and return types
+    queryFilter(
+      eventFilter: EventFilter,
+      fromBlockOrBlockhash?: string | number,
+      toBlock?: string | number,
+    ): Promise<EventLog[]>
+    removeAllListeners(eventName?: ExtractAbiEventNames<TAbi>): Contract<TAbi>
+    // TODO: Improve `eventFilter` type
+    removeAllListeners(eventFilter: EventFilter): Contract<TAbi>
+    removeListener: EventListener<TAbi>
+  }>
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Functions
+
+type Functions<
+  TAbi extends Abi,
+  Options extends {
+    ReturnType?: any
+    ReturnTypeAsArray?: boolean
+  } = {
+    ReturnTypeAsArray: false
+  },
+> = UnionToIntersection<
+  {
+    // 1. Iterate through all items in ABI
+    // 2. Set non-functions to `never`
+    // 3. Convert functions to TypeScript function signatures
+    [K in
+      keyof TAbi]: TAbi[K] extends infer TAbiFunction extends AbiFunction & {
+      type: 'function'
+    }
+      ? {
+          // If function name occurs more than once, it is overloaded. Grab full string signature as name (what ethers does).
+          [_ in
+            CountOccurrences<TAbi, { name: TAbiFunction['name'] }> extends 1
+              ? AbiItemName<TAbiFunction>
+              : AbiItemName<TAbiFunction, true>]: (
+            ...args: [
+              ...args: TAbiFunction['inputs'] extends infer TInputs extends readonly AbiParameter[]
+                ? AbiParametersToPrimitiveTypes<TInputs>
+                : never,
+              // Tack `overrides` onto end
+              // TODO: TypeScript doesn't preserve tuple labels when merging
+              // https://github.com/microsoft/TypeScript/issues/43020
+              overrides?: GetOverridesForAbiStateMutability<
+                TAbiFunction['stateMutability']
+              >,
+            ]
+          ) => Promise<
+            // Return a custom return type if specified. Otherwise, calculate return type.
+            IsUnknown<Options['ReturnType']> extends true
+              ? AbiFunctionReturnType<TAbiFunction> extends infer TAbiFunctionReturnType
+                ? Options['ReturnTypeAsArray'] extends true
+                  ? [TAbiFunctionReturnType]
+                  : TAbiFunctionReturnType
+                : never
+              : Options['ReturnType']
+          >
+        }
+      : never
+  }[number]
+>
+
+// Get return type for function based on `AbiStateMutability`
+type AbiFunctionReturnType<
+  TAbiFunction extends AbiFunction & {
+    type: 'function'
+  },
+> = ({
+  payable: ContractTransaction
+  nonpayable: ContractTransaction
+} & {
+  [_ in
+    'pure' | 'view']: TAbiFunction['outputs']['length'] extends infer TLength
+    ? TLength extends 0
+      ? void // If there are no outputs, return `void`
+      : TLength extends 1
+      ? AbiParameterToPrimitiveType<TAbiFunction['outputs'][0]>
+      : {
+          [Output in
+            TAbiFunction['outputs'][number] as Output extends {
+              name: string
+            }
+              ? Output['name'] extends ''
+                ? never
+                : Output['name']
+              : never]: AbiParameterToPrimitiveType<Output>
+        } & AbiParametersToPrimitiveTypes<TAbiFunction['outputs']>
+    : never
+})[TAbiFunction['stateMutability']]
+
+type InterfaceFunctions<TAbi extends Abi> = UnionToIntersection<
+  {
+    [K in
+      keyof TAbi]: TAbi[K] extends infer TAbiFunction extends AbiFunction & {
+      type: 'function'
+    }
+      ? {
+          [_ in AbiItemName<TAbiFunction, true>]: FunctionFragment // TODO: Infer `FunctionFragment` type
+        }
+      : never
+  }[number]
+>
+
+type InterfaceEvents<TAbi extends Abi> = UnionToIntersection<
+  {
+    [K in keyof TAbi]: TAbi[K] extends infer TAbiEvent extends AbiEvent
+      ? {
+          [_ in AbiItemName<TAbiEvent, true>]: FunctionFragment // TODO: Infer `EventFragment` type
+        }
+      : never
+  }[number]
+>
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Events
+
+export interface EventListener<TAbi extends Abi> {
+  <TEventName extends ExtractAbiEventNames<TAbi>>(
+    eventName: TEventName,
+    listener: Listener<TAbi, TEventName>,
+  ): Contract<TAbi>
+  (
+    // TODO: Improve `eventFilter` and `listener` types
+    eventFilter: EventFilter,
+    listener: Listener<TAbi, ExtractAbiEventNames<TAbi>>,
+  ): Contract<TAbi>
+}
+
+type Listener<
+  TAbi extends Abi,
+  TEventName extends string,
+  TAbiEvent extends AbiEvent = ExtractAbiEvent<TAbi, TEventName>,
+> = AbiParametersToPrimitiveTypes<
+  TAbiEvent['inputs']
+> extends infer TArgs extends readonly unknown[]
+  ? (...args: [...args: TArgs, event: Event<TAbiEvent>]) => void
+  : never
+
+type Filters<TAbi extends Abi> = UnionToIntersection<
+  {
+    [K in keyof TAbi]: TAbi[K] extends infer TAbiEvent extends AbiEvent
+      ? {
+          [_ in
+            CountOccurrences<TAbi, { name: TAbiEvent['name'] }> extends 1
+              ? AbiItemName<TAbiEvent>
+              : AbiItemName<TAbiEvent, true>]: (
+            ...args: TAbiEvent['inputs'] extends infer TAbiParameters extends readonly (AbiParameter & {
+              indexed?: boolean
+            })[]
+              ? {
+                  // Only indexed event parameters may be filtered.
+                  [K in
+                    keyof TAbiParameters]: TAbiParameters[K]['indexed'] extends true
+                    ? AbiParameterToPrimitiveType<TAbiParameters[K]> | null
+                    : null
+                }
+              : never
+          ) => EventFilter
+        }
+      : never
+  }[number]
+>

--- a/playgrounds/functions/src/types.ts
+++ b/playgrounds/functions/src/types.ts
@@ -26,7 +26,7 @@ export type ContractParameters<
     | (Abi extends abi ? string : never) // fallback if `abi` is declared as `Abi`
 } & GetArgs<abi, functionName, args>
 
-type GetArgs<
+export type GetArgs<
   abi extends Abi | readonly unknown[] = Abi, // `readonly unknown[]` allows for non-const asserted types
   functionName extends string = string,
   args extends readonly unknown[] | undefined = readonly [],
@@ -104,6 +104,14 @@ export type ContractReturnType<
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+export type UnionToIntersection<U> = (
+  U extends unknown
+    ? (arg: U) => 0
+    : never
+) extends (arg: infer I) => 0
+  ? I
+  : never
+
 type IsUnion<T, C = T> = T extends C ? ([C] extends [T] ? false : true) : never
 
 type UnionToTuple<U, Last = LastInUnion<U>> = [U] extends [never]
@@ -113,13 +121,6 @@ type LastInUnion<U> = UnionToIntersection<
   U extends unknown ? (x: U) => 0 : never
 > extends (x: infer L) => 0
   ? L
-  : never
-type UnionToIntersection<U> = (
-  U extends unknown
-    ? (arg: U) => 0
-    : never
-) extends (arg: infer I) => 0
-  ? I
   : never
 
 type PartialBy<TType, TKeys extends keyof TType> = ExactPartial<
@@ -165,3 +166,5 @@ export type DeepPartial<
   : T extends object
   ? { [P in keyof T]?: DeepPartial<T[P], MaxDepth, [...Depth, 1]> | undefined }
   : T
+
+export type IsUnknown<T> = unknown extends T ? true : false

--- a/playgrounds/functions/src/utils.ts
+++ b/playgrounds/functions/src/utils.ts
@@ -1,0 +1,142 @@
+import type {
+  AbiEvent,
+  AbiFunction,
+  AbiParameter,
+  AbiParametersToPrimitiveTypes,
+  AbiStateMutability,
+  Address,
+  ResolvedRegister,
+} from 'abitype'
+
+import type { ContractEventPayload, Overrides as EthersOverrides } from 'ethers'
+
+/**
+ * Get name for {@link AbiFunction} or {@link AbiEvent}
+ *
+ * @param TAbiItem - {@link AbiFunction} or {@link AbiEvent}
+ * @param IsSignature - Whether to return the signature instead of the name
+ * @returns Name or signature of function or event
+ *
+ * @example
+ * type Result = AbiItemName<{ type: 'function'; name: 'Foo'; … }>
+ */
+export type AbiItemName<
+  TAbiItem extends (AbiFunction & { type: 'function' }) | AbiEvent,
+  IsSignature extends boolean = false,
+> = IsSignature extends true
+  ? TAbiItem['inputs'] extends infer TAbiParameters extends readonly AbiParameter[]
+    ? `${TAbiItem['name']}(${Join<
+        [...{ [K in keyof TAbiParameters]: TAbiParameters[K]['type'] }],
+        ','
+      >})`
+    : never
+  : TAbiItem['name']
+
+/**
+ * Get overrides for {@link AbiStateMutability}
+ *
+ * @param TAbiStateMutability - {@link AbiStateMutability}
+ * @returns Overrides for {@link TAbiStateMutability}
+ *
+ * @example
+ * type Result = GetOverridesForAbiStateMutability<'pure'>
+ */
+export type GetOverridesForAbiStateMutability<
+  TAbiStateMutability extends AbiStateMutability,
+> = {
+  nonpayable: Overrides & { from?: Address }
+  payable: PayableOverrides & { from?: Address }
+  pure: CallOverrides
+  view: CallOverrides
+}[TAbiStateMutability]
+
+// Update `ethers.Overrides` to use abitype config
+export interface Overrides extends EthersOverrides {
+  gasLimit?: ResolvedRegister['BigIntType']
+  gasPrice?: ResolvedRegister['BigIntType']
+  maxFeePerGas?: ResolvedRegister['BigIntType']
+  maxPriorityFeePerGas?: ResolvedRegister['BigIntType']
+  nonce?: ResolvedRegister['IntType']
+}
+
+// Update `ethers.PayableOverrides` to use abitype config
+export interface PayableOverrides extends Overrides {
+  value?: ResolvedRegister['IntType'] | ResolvedRegister['BigIntType']
+}
+
+// Update `ethers.CallOverrides` to use abitype config
+export interface CallOverrides extends PayableOverrides {
+  blockTag?: NonNullable<EthersOverrides['blockTag']>
+  from?: Address
+}
+
+// Add type inference to `ethers.Event`
+export type Event<TAbiEvent extends AbiEvent> = Omit<
+  ContractEventPayload,
+  'args' | 'eventName' | 'eventSignature'
+> & {
+  args: AbiParametersToPrimitiveTypes<TAbiEvent['inputs']>
+  event: TAbiEvent['name']
+  eventSignature: AbiItemName<TAbiEvent, true>
+}
+/**
+ * Joins {@link Items} into string separated by {@link Separator}
+ *
+ * @param Items - Items to join
+ * @param Separator - Separator to use
+ * @returns Joined string
+ *
+ * @example
+ * type Result = Join<['foo', 'bar'], '-'>
+ */
+export type Join<
+  Items extends string[],
+  Separator extends string | number,
+> = Items extends [infer First, ...infer Rest]
+  ? First extends string
+    ? Rest extends string[]
+      ? Rest extends []
+        ? `${First}`
+        : `${First}${Separator}${Join<Rest, Separator>}`
+      : never
+    : never
+  : ''
+/**
+ * Count occurrences of {@link TType} in {@link TArray}
+ *
+ * @param TArray - Array to count occurrences in
+ * @param TType - Type to count occurrences of
+ * @returns Number of occurrences of {@link TType} in {@link TArray}
+ *
+ * @example
+ * type Result = CountOccurrences<['foo', 'bar', 'foo'], 'foo'>
+ */
+export type CountOccurrences<
+  TArray extends readonly unknown[],
+  TType,
+> = FilterNever<
+  [
+    ...{
+      [K in keyof TArray]: TArray[K] extends TType ? TArray[K] : never
+    },
+  ]
+>['length']
+/**
+ * Removes all occurrences of `never` from {@link TArray}
+ *
+ * @param TArray - Array to filter
+ * @returns Array with `never` removed
+ *
+ * @example
+ * type Result = FilterNever<[1, 2, never, 3, never, 4]>
+ */
+export type FilterNever<TArray extends readonly unknown[]> =
+  TArray['length'] extends 0
+    ? []
+    : TArray extends [infer THead, ...infer TRest]
+    ? IsNever<THead> extends true
+      ? FilterNever<TRest>
+      : [THead, ...FilterNever<TRest>]
+    : never
+
+type IsNever<T> = [T] extends [never] ? true : false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,10 @@ importers:
       abitype:
         specifier: workspace:*
         version: link:../../packages/abitype
+    devDependencies:
+      ethers:
+        specifier: ^6.5.1
+        version: 6.5.1
 
   playgrounds/performance:
     devDependencies:


### PR DESCRIPTION
## Description

This PR aims to add support for folks that relied on Typechain and are now using Abitype with ethers.
By creating a working playground this should give a starting point for anyone that might need this.
This is essentially a updated port of wagmi's pre 1.0 code but having it here makes more sense in my opinion.

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://github.com/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md)
- [x] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a playground example of using `abitype` with ethers. 

### Detailed summary
- Added a playground example of using `abitype` with ethers.
- Updated dependencies in `playgrounds/functions/package.json` and `pnpm-lock.yaml`.
- Added new types and functions in `playgrounds/functions/src/types.ts` and `playgrounds/functions/src/utils.ts`.
- Added new tests in `playgrounds/functions/src/ethers.test-d.ts`.
- Updated `playgrounds/functions/src/ethers.ts` to include new functions.

> The following files were skipped due to too many changes: `playgrounds/functions/src/ethers.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->