### PR TITLE
Add Hex zod validator to abitype

### DIFF
--- a/packages/abitype/src/zod.ts
+++ b/packages/abitype/src/zod.ts
@@ -26,7 +26,7 @@ export const Address = z.string().transform((val, ctx) => {
     })
   }
 
-  return val as `0x${string}`
+  return val as AddressType
 })
 
 export const Hex = z.string().transform((val, ctx) => {

--- a/packages/abitype/src/zod.ts
+++ b/packages/abitype/src/zod.ts
@@ -26,7 +26,20 @@ export const Address = z.string().transform((val, ctx) => {
     })
   }
 
-  return val as AddressType
+  return val as `0x${string}`
+})
+
+export const Hex = z.string().transform((val, ctx) => {
+  const regex = /^0x[0-9a-fA-F]*$/
+
+  if (!regex.test(val)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Invalid Hex ${val}`,
+    })
+  }
+
+  return val as `0x${string}`
 })
 
 // From https://docs.soliditylang.org/en/latest/abi-spec.html#types


### PR DESCRIPTION
WIP

- Add hex type
- Use hardcoded `0x${string}` type. Otherwise the return type is wrong in the corner case of someone overriding the Address type to be a string or something else
- Update Address type for same reason

TODO update docs and tests

## Description

What changes are made in this PR? Is it a feature or a bug fix?

## Additional Information

Before submitting this issue, please make sure you do the following.

- [ ] Read the [contributing guide](https://github.com/wevm/abitype/blob/main/.github/CONTRIBUTING.md)
- [ ] Added documentation related to the changes made.
- [ ] Added or updated tests (and snapshots) related to the changes made.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new validation function `Hex` to check if a string is a valid hexadecimal value. 

### Detailed summary
- Added `Hex` validation function to check for valid hexadecimal values.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->