### PR TITLE
Updating broken examples directory link (to point to playground)

### DIFF
--- a/docs/pages/guide/walkthrough.md
+++ b/docs/pages/guide/walkthrough.md
@@ -422,7 +422,7 @@ There are a few other ways to improve the typing that are out of scope for this 
 - `args` can be an empty array if the function doesn't take any arguments, but you could conditionally add `args` to `config` if it's not empty.
 - `readContract`'s return type is an array, but you could unwrap it if the function only has one output or transform it to another type depending on your implementation.
 
-The preceding points are all implemented in throughout the [examples](https://github.com/wevm/abitype/tree/main/examples) in this directory so check them out if you're interested.
+The preceding points are all implemented in throughout the [examples](https://github.com/wevm/abitype/tree/main/playgrounds) in this directory so check them out if you're interested.
 
 [^1]: We use the `declare` keyword so we don't need to worry about the implementation. In this case, the implementation would look something like encoding arguments and sending with the [`eth_call`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_call) RPC method.
 [^2]: If this was a real function that read via RPC, we'd likely want to make it `async` and return a `Promise`, but we'll leave that out for simplicity.


### PR DESCRIPTION
## Description

Just updating the broken link in the docs to the `examples` (which looks like it's been renamed to `playground`)

## Additional Information

Before submitting this issue, please make sure you do the following.

- [X] Read the [contributing guide](https://github.com/wevm/abitype/blob/main/.github/CONTRIBUTING.md)
- [X] Added documentation related to the changes made.
- [X] Added or updated tests (and snapshots) related to the changes made.


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Updated the link to the `examples` directory in the `walkthrough.md` file.
- Added footnotes explaining the usage of the `declare` keyword and the possibility of making the `readContract` function `async`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->