### PR TITLE
Fixes regex for fallback signatures

### DIFF
--- a/.changeset/poor-garlics-invite.md
+++ b/.changeset/poor-garlics-invite.md
@@ -1,0 +1,5 @@
+---
+"abitype": patch
+---
+
+Fixed regex for fallback signatures.

--- a/packages/abitype/src/human-readable/parseAbiItem.test.ts
+++ b/packages/abitype/src/human-readable/parseAbiItem.test.ts
@@ -61,6 +61,12 @@ test.each([
       ],
     },
   },
+  {
+    signature: ['fallback() external'],
+    expected: {
+      type: 'fallback',
+    },
+  },
 ])('parseAbiItem($signature)', ({ signature, expected }) => {
   expect(parseAbiItem(signature)).toEqual(expected)
 })

--- a/packages/abitype/src/human-readable/runtime/signatures.test.ts
+++ b/packages/abitype/src/human-readable/runtime/signatures.test.ts
@@ -217,7 +217,13 @@ test('execConstructorSignature', () => {
 })
 
 test('isFallbackSignature', () => {
-  expect(isFallbackSignature('fallback()')).toMatchInlineSnapshot('true')
+  expect(isFallbackSignature('fallback() external')).toMatchInlineSnapshot(
+    'true',
+  )
+  expect(
+    isFallbackSignature('fallback() external payable'),
+  ).toMatchInlineSnapshot('true')
+
   expect(isFallbackSignature('function name(string)')).toMatchInlineSnapshot(
     'false',
   )

--- a/packages/abitype/src/human-readable/runtime/signatures.ts
+++ b/packages/abitype/src/human-readable/runtime/signatures.ts
@@ -73,8 +73,9 @@ export function execConstructorSignature(signature: string) {
   }>(constructorSignatureRegex, signature)
 }
 
-// https://regexr.com/78u18
-const fallbackSignatureRegex = /^fallback\(\)$/
+// https://regexr.com/7srtn
+const fallbackSignatureRegex =
+  /^fallback\(\) external(?:\s(?<stateMutability>payable{1}))?$/
 export function isFallbackSignature(signature: string) {
   return fallbackSignatureRegex.test(signature)
 }


### PR DESCRIPTION
## Description

Bug fix for fallback signatures. Previously, it was not consistent with the docs or types.

## Additional Information

Before submitting this issue, please make sure you do the following.

- [x] Read the [contributing guide](https://github.com/wevm/abitype/blob/main/.github/CONTRIBUTING.md)
- [x] Added documentation related to the changes made.
- [x] Added or updated tests (and snapshots) related to the changes made.


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to fix the regex for fallback signatures in the `abitype` package.

### Detailed summary
- Updated regex for fallback signatures to include `external` and optional `payable` state mutability.
- Added tests to cover the new regex pattern.
- Improved accuracy in identifying fallback signatures.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->