### PR TITLE
fix: flatten nested arrays in parseAbiParameters

### DIFF
--- a/.changeset/cool-buttons-rush.md
+++ b/.changeset/cool-buttons-rush.md
@@ -1,0 +1,5 @@
+---
+"abitype": patch
+---
+
+Fix type detection when using an array in (encode|parse)AbiParameters

--- a/.changeset/cool-buttons-rush.md
+++ b/.changeset/cool-buttons-rush.md
@@ -2,4 +2,4 @@
 "abitype": patch
 ---
 
-Fix type detection when using an array in (encode|parse)AbiParameters
+Fixed type detection when using an array in `ParseAbiParameters`

--- a/packages/abitype/src/human-readable/parseAbiParameters.test-d.ts
+++ b/packages/abitype/src/human-readable/parseAbiParameters.test-d.ts
@@ -109,4 +109,52 @@ test('parseAbiParameters', () => {
   expectTypeOf(parseAbiParameters(param)).toEqualTypeOf<
     readonly AbiParameter[]
   >()
+
+  expectTypeOf(parseAbiParameters(['(uint256 a),(uint256 b)'])).toEqualTypeOf<
+    readonly [
+      {
+        readonly type: 'tuple'
+        readonly components: readonly [
+          {
+            readonly type: 'uint256'
+            readonly name: 'a'
+          },
+        ]
+      },
+      {
+        readonly type: 'tuple'
+        readonly components: readonly [
+          {
+            readonly type: 'uint256'
+            readonly name: 'b'
+          },
+        ]
+      },
+    ]
+  >()
+
+  expectTypeOf(
+    parseAbiParameters(['(uint256 a)', '(uint256 b)']),
+  ).toEqualTypeOf<
+    readonly [
+      {
+        readonly type: 'tuple'
+        readonly components: readonly [
+          {
+            readonly type: 'uint256'
+            readonly name: 'a'
+          },
+        ]
+      },
+      {
+        readonly type: 'tuple'
+        readonly components: readonly [
+          {
+            readonly type: 'uint256'
+            readonly name: 'b'
+          },
+        ]
+      },
+    ]
+  >()
 })

--- a/packages/abitype/src/human-readable/parseAbiParameters.ts
+++ b/packages/abitype/src/human-readable/parseAbiParameters.ts
@@ -52,7 +52,9 @@ export type ParseAbiParameters<
               : never
           } extends infer Mapped extends readonly unknown[]
           ? Filter<Mapped, never> extends readonly [...infer Content]
-            ? DeepFlatten<Content>
+            ? Content['length'] extends 0
+              ? never
+              : DeepFlatten<Content>
             : never
           : never
         : never
@@ -142,5 +144,5 @@ export function parseAbiParameters<
   if (abiParameters.length === 0)
     throw new InvalidAbiParametersError({ params })
 
-  return abiParameters as unknown as ParseAbiParameters<TParams>
+  return abiParameters as ParseAbiParameters<TParams>
 }


### PR DESCRIPTION
## Description

Hopefully fix https://github.com/wevm/abitype/issues/231

## Additional Information

Introduce a `DeepFlatten` and use it in `ParseAbiParameters` instead of assuming that `Filter<Mapped, never>` has always only one element.

**NOTE**: I had to update `parseAbiParameters` to `return abiParameters as unknown as ParseAbiParameters<TParams>` for the compiler to be happy but waiting for feedback.

Before submitting this issue, please make sure you do the following.

- [x ] Read the [contributing guide](https://github.com/wevm/abitype/blob/main/.github/CONTRIBUTING.md)
- [x ] Added documentation related to the changes made.
- [ ] Added or updated tests (and snapshots) related to the changes made.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing type detection in `ParseAbiParameters` when using an array.

### Detailed summary
- Fixed type detection issue with arrays in `ParseAbiParameters`
- Added `DeepFlatten` type for flattening arrays
- Updated documentation for `DeepFlatten`
- Improved parsing of human-readable ABI parameters to `AbiParameter` objects

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->