### PR TITLE
fix: type-level human-readable abi item parameters/scope/state mutability parsing

### DIFF
--- a/.changeset/plenty-pandas-kneel.md
+++ b/.changeset/plenty-pandas-kneel.md
@@ -1,0 +1,5 @@
+---
+"abitype": patch
+---
+
+Fixed human-readable ABI item parsing with nested tuple parameters.

--- a/packages/abitype/src/human-readable/parseAbiItem.test-d.ts
+++ b/packages/abitype/src/human-readable/parseAbiItem.test-d.ts
@@ -156,3 +156,12 @@ test('parseAbiItem', () => {
   const signature: string = 'function foo()'
   expectTypeOf(parseAbiItem(signature)).toEqualTypeOf<Abi[number]>()
 })
+
+test('nested tuples', () => {
+  const formattedAbiItem =
+    'function stepChanges((uint256 characterID, uint64 newPosition, uint24 xp, uint24 epoch, uint8 hp, (int32 x, int32 y, uint8 hp, uint8 kind)[5] monsters, (uint8 monsterIndexPlus1, uint8 attackCardsUsed1, uint8 attackCardsUsed2, uint8 defenseCardsUsed1, uint8 defenseCardsUsed2) battle) stateChanges, uint256 action, bool revetOnInvalidMoves) pure returns ((uint256 characterID, uint64 newPosition, uint24 xp, uint24 epoch, uint8 hp, (int32 x, int32 y, uint8 hp, uint8 kind)[5] monsters, (uint8 monsterIndexPlus1, uint8 attackCardsUsed1, uint8 attackCardsUsed2, uint8 defenseCardsUsed1, uint8 defenseCardsUsed2) battle))'
+
+  const abiItem = parseAbiItem(formattedAbiItem)
+  expectTypeOf(abiItem.stateMutability).toEqualTypeOf<'pure'>()
+  expectTypeOf(abiItem.inputs.length).toEqualTypeOf<3>()
+})

--- a/packages/abitype/src/human-readable/parseAbiItem.test.ts
+++ b/packages/abitype/src/human-readable/parseAbiItem.test.ts
@@ -260,4 +260,3 @@ test('nested tuples', () => {
   `,
   )
 })
-

--- a/packages/abitype/src/human-readable/parseAbiItem.test.ts
+++ b/packages/abitype/src/human-readable/parseAbiItem.test.ts
@@ -87,3 +87,177 @@ test.each([
 ])('parseAbiItem($signature)', ({ signature, expected }) => {
   expect(parseAbiItem(signature)).toEqual(expected)
 })
+
+test('nested tuples', () => {
+  const formattedAbiItem =
+    'function stepChanges((uint256 characterID, uint64 newPosition, uint24 xp, uint24 epoch, uint8 hp, (int32 x, int32 y, uint8 hp, uint8 kind)[5] monsters, (uint8 monsterIndexPlus1, uint8 attackCardsUsed1, uint8 attackCardsUsed2, uint8 defenseCardsUsed1, uint8 defenseCardsUsed2) battle) stateChanges, uint256 action, bool revetOnInvalidMoves) pure returns ((uint256 characterID, uint64 newPosition, uint24 xp, uint24 epoch, uint8 hp, (int32 x, int32 y, uint8 hp, uint8 kind)[5] monsters, (uint8 monsterIndexPlus1, uint8 attackCardsUsed1, uint8 attackCardsUsed2, uint8 defenseCardsUsed1, uint8 defenseCardsUsed2) battle))'
+  expect(parseAbiItem(formattedAbiItem)).toMatchInlineSnapshot(
+    `
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "name": "characterID",
+              "type": "uint256",
+            },
+            {
+              "name": "newPosition",
+              "type": "uint64",
+            },
+            {
+              "name": "xp",
+              "type": "uint24",
+            },
+            {
+              "name": "epoch",
+              "type": "uint24",
+            },
+            {
+              "name": "hp",
+              "type": "uint8",
+            },
+            {
+              "components": [
+                {
+                  "name": "x",
+                  "type": "int32",
+                },
+                {
+                  "name": "y",
+                  "type": "int32",
+                },
+                {
+                  "name": "hp",
+                  "type": "uint8",
+                },
+                {
+                  "name": "kind",
+                  "type": "uint8",
+                },
+              ],
+              "name": "monsters",
+              "type": "tuple[5]",
+            },
+            {
+              "components": [
+                {
+                  "name": "monsterIndexPlus1",
+                  "type": "uint8",
+                },
+                {
+                  "name": "attackCardsUsed1",
+                  "type": "uint8",
+                },
+                {
+                  "name": "attackCardsUsed2",
+                  "type": "uint8",
+                },
+                {
+                  "name": "defenseCardsUsed1",
+                  "type": "uint8",
+                },
+                {
+                  "name": "defenseCardsUsed2",
+                  "type": "uint8",
+                },
+              ],
+              "name": "battle",
+              "type": "tuple",
+            },
+          ],
+          "name": "stateChanges",
+          "type": "tuple",
+        },
+        {
+          "name": "action",
+          "type": "uint256",
+        },
+        {
+          "name": "revetOnInvalidMoves",
+          "type": "bool",
+        },
+      ],
+      "name": "stepChanges",
+      "outputs": [
+        {
+          "components": [
+            {
+              "name": "characterID",
+              "type": "uint256",
+            },
+            {
+              "name": "newPosition",
+              "type": "uint64",
+            },
+            {
+              "name": "xp",
+              "type": "uint24",
+            },
+            {
+              "name": "epoch",
+              "type": "uint24",
+            },
+            {
+              "name": "hp",
+              "type": "uint8",
+            },
+            {
+              "components": [
+                {
+                  "name": "x",
+                  "type": "int32",
+                },
+                {
+                  "name": "y",
+                  "type": "int32",
+                },
+                {
+                  "name": "hp",
+                  "type": "uint8",
+                },
+                {
+                  "name": "kind",
+                  "type": "uint8",
+                },
+              ],
+              "name": "monsters",
+              "type": "tuple[5]",
+            },
+            {
+              "components": [
+                {
+                  "name": "monsterIndexPlus1",
+                  "type": "uint8",
+                },
+                {
+                  "name": "attackCardsUsed1",
+                  "type": "uint8",
+                },
+                {
+                  "name": "attackCardsUsed2",
+                  "type": "uint8",
+                },
+                {
+                  "name": "defenseCardsUsed1",
+                  "type": "uint8",
+                },
+                {
+                  "name": "defenseCardsUsed2",
+                  "type": "uint8",
+                },
+              ],
+              "name": "battle",
+              "type": "tuple",
+            },
+          ],
+          "type": "tuple",
+        },
+      ],
+      "stateMutability": "pure",
+      "type": "function",
+    }
+  `,
+  )
+})
+

--- a/packages/abitype/src/human-readable/types/utils.test-d.ts
+++ b/packages/abitype/src/human-readable/types/utils.test-d.ts
@@ -676,6 +676,20 @@ test('_ParseFunctionParametersAndStateMutability', () => {
     Inputs: 'string bar'
     StateMutability: 'view'
   }>()
+
+  expectTypeOf<
+    _ParseFunctionParametersAndStateMutability<'function foo(string bar, uint256) external view'>
+  >().toEqualTypeOf<{
+    Inputs: 'string bar, uint256'
+    StateMutability: 'view'
+  }>()
+
+  expectTypeOf<
+    _ParseFunctionParametersAndStateMutability<'function stepChanges((uint256 characterID, uint64 newPosition, uint24 xp, uint24 epoch, uint8 hp, (int32 x, int32 y, uint8 hp, uint8 kind)[5] monsters, (uint8 monsterIndexPlus1, uint8 attackCardsUsed1, uint8 attackCardsUsed2, uint8 defenseCardsUsed1, uint8 defenseCardsUsed2) battle) stateChanges, uint256 action, bool revetOnInvalidMoves) pure returns ((uint256 characterID, uint64 newPosition, uint24 xp, uint24 epoch, uint8 hp, (int32 x, int32 y, uint8 hp, uint8 kind)[5] monsters, (uint8 monsterIndexPlus1, uint8 attackCardsUsed1, uint8 attackCardsUsed2, uint8 defenseCardsUsed1, uint8 defenseCardsUsed2) battle))'>
+  >().toEqualTypeOf<{
+    Inputs: '(uint256 characterID, uint64 newPosition, uint24 xp, uint24 epoch, uint8 hp, (int32 x, int32 y, uint8 hp, uint8 kind)[5] monsters, (uint8 monsterIndexPlus1, uint8 attackCardsUsed1, uint8 attackCardsUsed2, uint8 defenseCardsUsed1, uint8 defenseCardsUsed2) battle) stateChanges, uint256 action, bool revetOnInvalidMoves'
+    StateMutability: 'pure'
+  }>()
 })
 
 test('_ParseTuple', () => {

--- a/packages/abitype/src/human-readable/types/utils.ts
+++ b/packages/abitype/src/human-readable/types/utils.ts
@@ -255,13 +255,26 @@ export type _ParseFunctionParametersAndStateMutability<
           | `${Scope} ${AbiStateMutability}`}`
       ? {
           Inputs: parameters
-          StateMutability: scopeOrStateMutability extends `${Scope} ${infer stateMutability extends AbiStateMutability}`
-            ? stateMutability
-            : scopeOrStateMutability extends AbiStateMutability
-              ? scopeOrStateMutability
-              : 'nonpayable'
+          StateMutability: _ParseStateMutability<scopeOrStateMutability>
         }
-      : never
+      : signature extends `function ${string}(${infer tail}`
+        ? _UnwrapNameOrModifier<tail> extends {
+            nameOrModifier: infer scopeOrStateMutability extends string
+            End: infer parameters
+          }
+          ? {
+              Inputs: parameters
+              StateMutability: _ParseStateMutability<scopeOrStateMutability>
+            }
+          : never
+        : never
+
+type _ParseStateMutability<signature extends string> =
+  signature extends `${Scope} ${infer stateMutability extends AbiStateMutability}`
+    ? stateMutability
+    : signature extends AbiStateMutability
+      ? signature
+      : 'nonpayable'
 
 type _ParseConstructorParametersAndStateMutability<signature extends string> =
   signature extends `constructor(${infer parameters}) payable`


### PR DESCRIPTION
Fixes #243

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/abitype/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to ABIType!
----------------------------------------------------------------------->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves the parsing of human-readable ABI items with nested tuple parameters in the `abitype` package.

### Detailed summary
- Fixed parsing of human-readable ABI items with nested tuple parameters
- Updated tests for nested tuples in `parseAbiItem.test.ts`
- Added new type utilities for parsing function parameters and state mutability

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->