### PR TITLE
feat: signature from ABI item

### DIFF
--- a/.changeset/silly-pugs-clean.md
+++ b/.changeset/silly-pugs-clean.md
@@ -1,0 +1,5 @@
+---
+"abitype": minor
+---
+
+construct signatures from ABI

--- a/docs/pages/api/human.md
+++ b/docs/pages/api/human.md
@@ -483,6 +483,33 @@ Runtime functions for parsing and formatting human-readable ABIs.
 These functions throw [errors](#errors-1) for invalid inputs. Make sure you handle errors appropriately.
 :::
 
+### `signatureAbiItem`
+
+Formats [`Abi`](/api/types#abi) into the corresponding signature used to create selectors for both [functions](https://docs.soliditylang.org/en/develop/abi-spec.html#function-selector) and [events](https://docs.soliditylang.org/en/develop/abi-spec.html#events).
+
+| Name         | Description   | Type                        |
+| ------------ | ------------- | ----------------------------|
+| `abiItem`    | ABI item      | `AbiFunction` \| `AbiEvent` |
+| returns      | signature     | `string` (inferred)         |
+
+#### Example
+
+```ts twoslash
+import { signatureAbiItem } from 'abitype'
+
+const result = signatureAbiItem({
+//    ^? 
+
+
+
+  name: 'balanceOf',
+  type: 'function',
+  stateMutability: 'view',
+  inputs: [{ type: 'address', name: 'owner' }],
+  outputs: [{ type: 'uint256' }],
+})
+```
+
 ### `parseAbi`
 
 Parses human-readable ABI into JSON [`Abi`](/api/types#abi).

--- a/packages/abitype/src/exports/index.test.ts
+++ b/packages/abitype/src/exports/index.test.ts
@@ -15,6 +15,7 @@ it('exports', () => {
       "parseAbiItem",
       "parseAbiParameter",
       "parseAbiParameters",
+      "signatureAbiItem",
       "UnknownTypeError",
       "InvalidAbiItemError",
       "UnknownSolidityTypeError",

--- a/packages/abitype/src/exports/index.ts
+++ b/packages/abitype/src/exports/index.ts
@@ -103,6 +103,11 @@ export {
 } from '../human-readable/parseAbiParameters.js'
 
 export {
+  signatureAbiItem,
+  type signatureAbiItem,
+} from '../human-readable/signatureAbiItem.js'
+
+export {
   UnknownTypeError,
   InvalidAbiItemError,
   UnknownSolidityTypeError,

--- a/packages/abitype/src/human-readable/formatAbiParameter.ts
+++ b/packages/abitype/src/human-readable/formatAbiParameter.ts
@@ -52,7 +52,7 @@ export type FormatAbiParameter<
       : ''}`
 
 // https://regexr.com/7f7rv
-const tupleRegex = /^tuple(?<array>(\[(\d*)\])*)$/
+export const tupleRegex = /^tuple(?<array>(\[(\d*)\])*)$/
 
 /**
  * Formats {@link AbiParameter} to human-readable ABI parameter.

--- a/packages/abitype/src/human-readable/signatureAbiItem.bench.ts
+++ b/packages/abitype/src/human-readable/signatureAbiItem.bench.ts
@@ -1,0 +1,47 @@
+import { Fragment as FragmentV5 } from '@ethersproject/abi'
+import { Fragment as FragmentV6 } from 'ethers'
+import { bench, describe } from 'vitest'
+
+import { signatureAbiItem } from './signatureAbiItem.js'
+
+describe('Generate Function ABI signature', () => {
+  const basic = {
+    name: 'balanceOf',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [{ type: 'address' }, { type: 'address' }],
+    outputs: [{ name: 'balance', type: 'uint256' }],
+  } as const
+
+  bench('abitype', () => {
+    signatureAbiItem(basic)
+  })
+
+  bench('ethers@6', () => {
+    FragmentV6.from(basic).format('sighash')
+  })
+
+  bench('ethers@5', () => {
+    FragmentV5.fromObject(basic).format('sighash')
+  })
+})
+
+describe('Generate Event ABI signature', () => {
+  const basic = {
+    name: 'foo',
+    type: 'event',
+    inputs: [{ type: 'uint256' }, { type: 'uint256' }],
+  } as const
+
+  bench('abitype', () => {
+    signatureAbiItem(basic)
+  })
+
+  bench('ethers@6', () => {
+    FragmentV6.from(basic).format('sighash')
+  })
+
+  bench('ethers@5', () => {
+    FragmentV5.fromObject(basic).format('sighash')
+  })
+})

--- a/packages/abitype/src/human-readable/signatureAbiItem.test-d.ts
+++ b/packages/abitype/src/human-readable/signatureAbiItem.test-d.ts
@@ -1,0 +1,101 @@
+import { expectTypeOf, test } from 'vitest'
+
+import type { SignatureAbiItem } from './signatureAbiItem.js'
+
+test('SignatureAbiItem: function', () => {
+  expectTypeOf<
+    SignatureAbiItem<{
+      name: 'balanceOf'
+      type: 'function'
+      stateMutability: 'view'
+      inputs: [{ type: 'address' }, { type: 'address' }]
+      outputs: [{ name: 'balance'; type: 'uint256' }]
+    }>
+  >().toEqualTypeOf<'balanceOf(address,address)'>()
+  expectTypeOf<
+    SignatureAbiItem<{
+      name: 'balanceOf'
+      type: 'function'
+      stateMutability: 'view'
+      inputs: [{ type: 'address' }]
+      outputs: [{ name: 'balance'; type: 'uint256' }]
+    }>
+  >().toEqualTypeOf<'balanceOf(address)'>()
+  expectTypeOf<
+    SignatureAbiItem<{
+      name: 'balanceOf'
+      type: 'function'
+      stateMutability: 'view'
+      inputs: []
+      outputs: [{ name: 'balance'; type: 'uint256' }]
+    }>
+  >().toEqualTypeOf<'balanceOf()'>()
+  expectTypeOf<
+    SignatureAbiItem<{
+      type: 'function'
+      name: 'foo'
+      stateMutability: 'view'
+      inputs: [
+        {
+          type: 'tuple'
+          name: 'config'
+          components: [{ type: 'uint16'; name: '' }, { type: 'bool'; name: '' }]
+        },
+      ]
+      outputs: []
+    }>
+  >().toEqualTypeOf<'foo((uint16,bool))'>()
+  expectTypeOf<
+    SignatureAbiItem<{
+      type: 'function'
+      name: 'foo'
+      stateMutability: 'view'
+      inputs: [
+        {
+          type: 'tuple[]'
+          name: 'config'
+          components: [{ type: 'uint16'; name: '' }, { type: 'bool'; name: '' }]
+        },
+      ]
+      outputs: []
+    }>
+  >().toEqualTypeOf<'foo((uint16,bool)[])'>()
+})
+
+test('SignatureAbiItem: event', () => {
+  expectTypeOf<
+    SignatureAbiItem<{
+      readonly name: 'foo'
+      readonly type: 'event'
+      readonly inputs: [{ type: 'uint256' }, { type: 'uint256' }]
+    }>
+  >().toEqualTypeOf<'foo(uint256,uint256)'>()
+  expectTypeOf<
+    SignatureAbiItem<{
+      readonly name: 'foo'
+      readonly type: 'event'
+      readonly inputs: [{ type: 'uint256' }]
+    }>
+  >().toEqualTypeOf<'foo(uint256)'>()
+  expectTypeOf<
+    SignatureAbiItem<{
+      readonly name: 'foo'
+      readonly type: 'event'
+      readonly inputs: []
+    }>
+  >().toEqualTypeOf<'foo()'>()
+  expectTypeOf<
+    SignatureAbiItem<{
+      name: 'foo'
+      type: 'event'
+      inputs: [{ type: 'tuple'; components: [{ type: 'uint256' }] }]
+    }>
+  >().toEqualTypeOf<'foo((uint256))'>()
+  expectTypeOf<
+    SignatureAbiItem<{
+      name: 'foo'
+      type: 'event'
+      inputs: [{ type: 'tuple[]'; components: [{ type: 'uint256' }] }]
+    }>
+  >().toEqualTypeOf<'foo((uint256)[])'>()
+})

--- a/packages/abitype/src/human-readable/signatureAbiItem.test.ts
+++ b/packages/abitype/src/human-readable/signatureAbiItem.test.ts
@@ -1,0 +1,120 @@
+import { expect, test } from 'vitest'
+import { signatureAbiItem } from './signatureAbiItem.js'
+
+test.each([
+  {
+    signature: signatureAbiItem({
+      name: 'balanceOf',
+      type: 'function',
+      stateMutability: 'view',
+      inputs: [{ type: 'address' }, { type: 'address' }],
+      outputs: [{ name: 'balance', type: 'uint256' }],
+    }),
+    expected: 'balanceOf(address,address)',
+  },
+  {
+    signature: signatureAbiItem({
+      name: 'balanceOf',
+      type: 'function',
+      stateMutability: 'view',
+      inputs: [{ type: 'address' }],
+      outputs: [{ name: 'balance', type: 'uint256' }],
+    }),
+    expected: 'balanceOf(address)',
+  },
+  {
+    signature: signatureAbiItem({
+      name: 'balanceOf',
+      type: 'function',
+      stateMutability: 'view',
+      inputs: [],
+      outputs: [{ name: 'balance', type: 'uint256' }],
+    }),
+    expected: 'balanceOf()',
+  },
+  {
+    signature: signatureAbiItem({
+      type: 'function',
+      name: 'foo',
+      stateMutability: 'view',
+      inputs: [
+        {
+          type: 'tuple',
+          name: 'config',
+          components: [
+            { type: 'uint16', name: '' },
+            { type: 'bool', name: '' },
+          ],
+        },
+      ],
+      outputs: [],
+    }),
+    expected: 'foo((uint16,bool))',
+  },
+  {
+    signature: signatureAbiItem({
+      type: 'function',
+      name: 'foo',
+      stateMutability: 'view',
+      inputs: [
+        {
+          type: 'tuple[]',
+          name: 'config',
+          components: [
+            { type: 'uint16', name: '' },
+            { type: 'bool', name: '' },
+          ],
+        },
+      ],
+      outputs: [],
+    }),
+    expected: 'foo((uint16,bool)[])',
+  },
+])('signatureAbiItem: function', (t) => {
+  expect(t.signature).toEqual(t.expected)
+})
+
+test.each([
+  {
+    signature: signatureAbiItem({
+      name: 'foo',
+      type: 'event',
+      inputs: [{ type: 'uint256' }, { type: 'uint256' }],
+    }),
+    expected: 'foo(uint256,uint256)',
+  },
+  {
+    signature: signatureAbiItem({
+      name: 'foo',
+      type: 'event',
+      inputs: [{ type: 'uint256' }],
+    }),
+    expected: 'foo(uint256)',
+  },
+  {
+    signature: signatureAbiItem({
+      name: 'foo',
+      type: 'event',
+      inputs: [],
+    }),
+    expected: 'foo()',
+  },
+  {
+    signature: signatureAbiItem({
+      name: 'foo',
+      type: 'event',
+      inputs: [{ type: 'tuple', components: [{ type: 'uint256' }] }],
+    }),
+    expected: 'foo((uint256))',
+  },
+  {
+    signature: signatureAbiItem({
+      name: 'foo',
+      type: 'event',
+      inputs: [{ type: 'tuple[]', components: [{ type: 'uint256' }] }],
+    }),
+    expected: 'foo((uint256)[])',
+  },
+])('signatureAbiItem: event', (t) => {
+  expect(t.signature).toEqual(t.expected)
+})

--- a/packages/abitype/src/human-readable/signatureAbiItem.ts
+++ b/packages/abitype/src/human-readable/signatureAbiItem.ts
@@ -1,0 +1,111 @@
+import type {
+  AbiEvent,
+  AbiEventParameter,
+  AbiFunction,
+  AbiParameter,
+} from '../abi.js'
+import type { AssertName } from '../human-readable/types/signatures.js'
+import { execTyped } from '../regex.js'
+import { tupleRegex } from './formatAbiParameter.js'
+
+type ExtractArray<abiParameter extends AbiParameter | AbiEventParameter> =
+  abiParameter extends {
+    type: `tuple${infer array}`
+  }
+    ? array
+    : ''
+
+type TypesToCSV<T extends readonly (AbiParameter | AbiEventParameter)[]> =
+  T extends readonly [
+    infer First extends AbiParameter | AbiEventParameter,
+    ...infer Rest extends readonly (AbiParameter | AbiEventParameter)[],
+  ]
+    ? `${First extends {
+        components: infer Component extends readonly (
+          | AbiParameter
+          | AbiEventParameter
+        )[]
+      }
+        ? `(${TypesToCSV<Component>})${ExtractArray<First>}`
+        : First['type']}${Rest['length'] extends 0 ? '' : `,${TypesToCSV<Rest>}`}`
+    : ''
+
+/**
+ * Formats an ABI item into a signature
+ *
+ * @param abiItem - ABI item
+ * @returns A signature
+ *
+ * @example
+ * type Result = SignatureAbiParameter({ name: 'foo', type: 'event', inputs: [{ type: 'uint256' }, { type: 'uint256' }] })
+ * //   ^? type Result: foo(uint256,uint256)
+ */
+export type SignatureAbiItem<abiItem extends AbiFunction | AbiEvent> =
+  | AbiFunction
+  | AbiEvent extends abiItem
+  ? string
+  : `${AssertName<abiItem['name']>}(${TypesToCSV<abiItem['inputs']>})`
+
+/**
+ * Formats an ABI function into a signature
+ * Function: https://docs.soliditylang.org/en/develop/abi-spec.html#function-selector
+ * Event: https://docs.soliditylang.org/en/develop/abi-spec.html#events
+ *
+ * @param abiItem - ABI item
+ * @returns A signature
+ *
+ * @example
+ * const signatureAbi = signatureAbiItem({ name: 'foo', type: 'event', inputs: [{ type: 'uint256' }, { type: 'uint256' }] })
+ * //    ^? const signatureAbiItem: foo(uint256,uint256)
+ */
+export function signatureAbiItem<const abiItem extends AbiFunction | AbiEvent>(
+  abiItem: abiItem,
+): SignatureAbiItem<abiItem> {
+  return `${abiItem.name}(${abiItem.inputs.map((param) => signatureAbiParameter(param)).join(',')})` as SignatureAbiItem<abiItem>
+}
+
+/**
+ * Formats an ABI parameter into a piece of a signature
+ *
+ * @param abiParameter - ABI parameter
+ * @returns A piece of a signature
+ *
+ * @example
+ * type Result = SignatureAbiParameter({ type: 'uint256' })
+ * //   ^? type Result: uint256
+ */
+export type SignatureAbiParameter<
+  abiParameter extends AbiParameter | AbiEventParameter,
+> = TypesToCSV<[abiParameter]>[0]
+
+/**
+ * Formats an ABI parameter into a piece of a signature
+ *
+ * @param abiParameter - ABI parameter
+ * @returns A piece of a signature
+ *
+ * @example
+ * const signatureAbi = signatureAbiParameter({ type: 'uint256' })
+ * //    ^? const signatureAbiItem: uint256
+ */
+export function signatureAbiParameter<
+  const abiParameter extends AbiParameter | AbiEventParameter,
+>(abiParameter: abiParameter): SignatureAbiParameter<abiParameter> {
+  let type = abiParameter.type
+  if (tupleRegex.test(abiParameter.type) && 'components' in abiParameter) {
+    type = '('
+    const length = abiParameter.components.length as number
+    for (let i = 0; i < length; i++) {
+      const component = abiParameter.components[i]!
+      type += signatureAbiParameter(component)
+      if (i < length - 1) type += ','
+    }
+    const result = execTyped<{ array?: string }>(tupleRegex, abiParameter.type)
+    type += `)${result?.array ?? ''}`
+    return signatureAbiParameter({
+      ...abiParameter,
+      type,
+    }) as SignatureAbiParameter<abiParameter>
+  }
+  return abiParameter.type
+}


### PR DESCRIPTION
## Goal

Solidity allows overloading functions & events - that is to say, you can for example have multiple events with the same name. To avoid this being an issue, Solidity [converts ABI entries](https://ethereum.stackexchange.com/a/135206/140076) to a signature which is then used to generate a "selector" (a part of the hash of the signature)

Generating this signature with a static type is important for downstream libraries like `viem` because the current lack of this feature means viem can't differentiate between events/functions with the same name leading to [subtle bugs](https://github.com/wevm/viem/discussions/260) and bypassing this limitation requires [dropping type safety](https://github.com/wevm/viem/discussions/2706) in viem.

## Open questions

1. I added the code to generate the signature from an ABI entry, but I didn't create the inverse (a `parse`). This is because signatures are lossy so you can't really compute the inverse anyway (but maybe somebody would benefit from even a partial inverse)
2. I added this to the `human-readable` folder since it felt like the closest place to add it, but this code doesn't fit particularly well in any of the existing folders I feel. Open to thoughts on this

## Test
```
 ✓ src/human-readable/signatureAbiItem.bench.ts (6) 5781ms

   ✓ Generate Function ABI signature (3) 2856ms
     · abitype   3,859,297.54 ops/sec ±1.31% (1929649 samples) fastest
     · ethers@6     47,912.60 ops/sec ±0.61% (  23957 samples) slowest
     · ethers@5    136,142.23 ops/sec ±0.69% (  68072 samples)

   ✓ Generate Event ABI signature (3) 2923ms
     · abitype   3,849,295.03 ops/sec ±1.51% (1924648 samples) fastest
     · ethers@6     77,291.49 ops/sec ±0.75% (  38646 samples) slowest
     · ethers@5    208,198.71 ops/sec ±0.80% ( 104100 samples)
```

Test
```
✓ src/signature/signatureAbiItem.test.ts (10)
   ✓ signatureAbiItem: function
   ✓ signatureAbiItem: function
   ✓ signatureAbiItem: function
   ✓ signatureAbiItem: function
   ✓ signatureAbiItem: function
   ✓ signatureAbiItem: event
   ✓ signatureAbiItem: event
   ✓ signatureAbiItem: event
   ✓ signatureAbiItem: event
   ✓ signatureAbiItem: event
```

Type test
```
✓ src/signature/signatureAbiItem.test-d.ts (2)
   ✓ SelectorAbiItem: function
   ✓ SelectorAbiItem: event
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `abitype` package by introducing the `signatureAbiItem` function for generating ABI signatures, improving type safety, and adding related tests and benchmarks.

### Detailed summary
- Added `signatureAbiItem` function to format ABI items into signatures.
- Exported `UnknownTypeError`, `InvalidAbiItemError`, and `signatureAbiItem`.
- Updated `tupleRegex` to be exported.
- Enhanced documentation for `signatureAbiItem`.
- Added tests for `signatureAbiItem` functionality.
- Implemented benchmarks comparing `abitype` with `ethers` library.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->