### PR TITLE
fix(`EIP712`): `chainId` should support `uint256` values

### DIFF
--- a/.changeset/shiny-kiwis-smash.md
+++ b/.changeset/shiny-kiwis-smash.md
@@ -2,4 +2,4 @@
 "abitype": patch
 ---
 
-EIP712 - `chainId` should support `uint256` values
+Updated `TypedDataDomain` `chainId` to support `uint256` values via `bigint`.

--- a/.changeset/shiny-kiwis-smash.md
+++ b/.changeset/shiny-kiwis-smash.md
@@ -1,0 +1,5 @@
+---
+"abitype": patch
+---
+
+EIP712 - `chainId` should support `uint256` values

--- a/packages/abitype/src/abi.ts
+++ b/packages/abitype/src/abi.ts
@@ -218,7 +218,7 @@ export type Abi = readonly (
 // Typed Data Types
 
 export type TypedDataDomain = {
-  chainId?: number | undefined
+  chainId?: number | bigint | string | undefined
   name?: string | undefined
   salt?: ResolvedRegister['bytesType']['outputs'] | undefined
   verifyingContract?: Address | undefined

--- a/packages/abitype/src/abi.ts
+++ b/packages/abitype/src/abi.ts
@@ -218,7 +218,7 @@ export type Abi = readonly (
 // Typed Data Types
 
 export type TypedDataDomain = {
-  chainId?: number | bigint | string | undefined
+  chainId?: number | bigint | undefined
   name?: string | undefined
   salt?: ResolvedRegister['bytesType']['outputs'] | undefined
   verifyingContract?: Address | undefined

--- a/packages/abitype/src/zod.ts
+++ b/packages/abitype/src/zod.ts
@@ -299,7 +299,7 @@ export const Abi = z
 // Typed Data Types
 
 export const TypedDataDomain = z.object({
-  chainId: z.number().optional(),
+  chainId: z.union([z.number(), z.string(), z.bigint()]).optional(),
   name: Identifier.optional(),
   salt: z.string().optional(),
   verifyingContract: Address.optional(),

--- a/packages/abitype/src/zod.ts
+++ b/packages/abitype/src/zod.ts
@@ -299,7 +299,7 @@ export const Abi = z
 // Typed Data Types
 
 export const TypedDataDomain = z.object({
-  chainId: z.union([z.number(), z.string(), z.bigint()]).optional(),
+  chainId: z.union([z.number(), z.bigint()]).optional(),
   name: Identifier.optional(),
   salt: z.string().optional(),
   verifyingContract: Address.optional(),


### PR DESCRIPTION
Since the largest integer that a `number` could safely represent in TypeScript is 2^53 - 1, bigger values that are supported by `uint256` cannot fit into it (some sample values in the issue).

Closes #256

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `TypedDataDomain` type to allow the `chainId` property to accept `bigint` values in addition to `number`, enhancing flexibility for handling larger numeric values.

### Detailed summary
- Updated `chainId` in `TypedDataDomain` type to accept `bigint` in `packages/abitype/src/abi.ts`.
- Modified `chainId` in `TypedDataDomain` Zod schema to allow `bigint` in `packages/abitype/src/zod.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->