### PR TITLE
fix: parse abi item fallback parsing

### DIFF
--- a/.changeset/red-turtles-refuse.md
+++ b/.changeset/red-turtles-refuse.md
@@ -1,0 +1,5 @@
+---
+"abitype": patch
+---
+
+Fixed parseAbiItem fallback parsing

--- a/.changeset/red-turtles-refuse.md
+++ b/.changeset/red-turtles-refuse.md
@@ -2,4 +2,4 @@
 "abitype": patch
 ---
 
-Fixed parseAbiItem fallback parsing
+Fixed `parseAbiItem` fallback signature parsing

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -50,7 +50,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        version: ['5.0.4', '5.1.6', '5.2.2', '5.3.3', '5.4.5', '5.5.2', 'latest']
+        version: ['5.0.4', '5.1.6', '5.2.2', '5.3.3', '5.4.5', '5.5.2', '5.6', 'latest']
 
     steps:
       - name: Clone repository

--- a/packages/abitype/jsr.json
+++ b/packages/abitype/jsr.json
@@ -8,12 +8,7 @@
     "./zod": "./src/exports/zod.ts"
   },
   "publish": {
-    "include": [
-      "LICENSE",
-      "README.md",
-      "CHANGELOG.md",
-      "src/**/*.ts"
-    ],
+    "include": ["LICENSE", "README.md", "CHANGELOG.md", "src/**/*.ts"],
     "exclude": [
       "src/**/*.bench.ts",
       "src/**/*.bench-d.ts",

--- a/packages/abitype/src/human-readable/integration.test.ts
+++ b/packages/abitype/src/human-readable/integration.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from 'vitest'
+import { formatAbiItem } from './formatAbiItem.js'
+import { parseAbiItem } from './parseAbiItem.js'
+
+test.each([
+  {
+    type: 'fallback',
+    stateMutability: 'payable',
+  } as const,
+  {
+    type: 'fallback',
+    stateMutability: 'nonpayable',
+  } as const,
+  {
+    type: 'receive',
+    stateMutability: 'payable',
+  } as const,
+  {
+    type: 'function',
+    name: 'foo',
+    inputs: [{ type: 'string' }],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  } as const,
+  {
+    type: 'event',
+    name: 'Foo',
+    inputs: [
+      { type: 'address', name: 'from', indexed: true },
+      { type: 'address', name: 'to', indexed: true },
+      { type: 'uint256', name: 'amount' },
+    ],
+  } as const,
+  {
+    type: 'constructor',
+    stateMutability: 'nonpayable',
+    inputs: [{ type: 'string' }],
+  } as const,
+  {
+    type: 'constructor',
+    stateMutability: 'payable',
+    inputs: [{ type: 'string' }],
+  } as const,
+  {
+    type: 'function',
+    name: 'initWormhole',
+    inputs: [
+      {
+        type: 'tuple[]',
+        name: 'configs',
+        components: [
+          {
+            type: 'uint256',
+            name: 'chainId',
+          },
+          {
+            type: 'uint16',
+            name: 'wormholeChainId',
+          },
+        ],
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  } as const,
+])('use of parseAbiItem - formatAbiItem should be reversible', (abiItem) => {
+  expect(parseAbiItem(formatAbiItem(abiItem))).toEqual(abiItem)
+})

--- a/packages/abitype/src/human-readable/parseAbiItem.test-d.ts
+++ b/packages/abitype/src/human-readable/parseAbiItem.test-d.ts
@@ -155,6 +155,22 @@ test('parseAbiItem', () => {
 
   const signature: string = 'function foo()'
   expectTypeOf(parseAbiItem(signature)).toEqualTypeOf<Abi[number]>()
+
+  // fallback
+  expectTypeOf(parseAbiItem('fallback() external')).toEqualTypeOf<{
+    readonly type: 'fallback'
+    readonly stateMutability: 'nonpayable'
+  }>()
+  expectTypeOf(parseAbiItem('fallback() external payable')).toEqualTypeOf<{
+    readonly type: 'fallback'
+    readonly stateMutability: 'payable'
+  }>()
+
+  // receive
+  expectTypeOf(parseAbiItem('receive() external payable')).toEqualTypeOf<{
+    readonly type: 'receive'
+    readonly stateMutability: 'payable'
+  }>()
 })
 
 test('nested tuples', () => {

--- a/packages/abitype/src/human-readable/parseAbiItem.test.ts
+++ b/packages/abitype/src/human-readable/parseAbiItem.test.ts
@@ -65,6 +65,14 @@ test.each([
     signature: ['fallback() external'],
     expected: {
       type: 'fallback',
+      stateMutability: 'nonpayable',
+    },
+  },
+  {
+    signature: ['fallback() external payable'],
+    expected: {
+      type: 'fallback',
+      stateMutability: 'payable',
     },
   },
 ])('parseAbiItem($signature)', ({ signature, expected }) => {

--- a/packages/abitype/src/human-readable/runtime/signatures.ts
+++ b/packages/abitype/src/human-readable/runtime/signatures.ts
@@ -79,6 +79,12 @@ const fallbackSignatureRegex =
 export function isFallbackSignature(signature: string) {
   return fallbackSignatureRegex.test(signature)
 }
+export function execFallbackSignature(signature: string) {
+  return execTyped<{
+    parameters: string
+    stateMutability: Extract<AbiStateMutability, 'payable'>
+  }>(fallbackSignatureRegex, signature)
+}
 
 // https://regexr.com/78u1k
 const receiveSignatureRegex = /^receive\(\) external payable$/

--- a/packages/abitype/src/human-readable/runtime/signatures.ts
+++ b/packages/abitype/src/human-readable/runtime/signatures.ts
@@ -82,7 +82,7 @@ export function isFallbackSignature(signature: string) {
 export function execFallbackSignature(signature: string) {
   return execTyped<{
     parameters: string
-    stateMutability: Extract<AbiStateMutability, 'payable'>
+    stateMutability?: Extract<AbiStateMutability, 'payable'>
   }>(fallbackSignatureRegex, signature)
 }
 

--- a/packages/abitype/src/human-readable/runtime/utils.test.ts
+++ b/packages/abitype/src/human-readable/runtime/utils.test.ts
@@ -93,6 +93,20 @@ test.each([
       stateMutability: 'payable',
     },
   },
+  {
+    signature: 'fallback() external payable',
+    expected: {
+      type: 'fallback',
+      stateMutability: 'payable',
+    },
+  },
+  {
+    signature: 'fallback() external',
+    expected: {
+      type: 'fallback',
+      stateMutability: 'nonpayable',
+    },
+  },
 ])('parseSignature($signature)', ({ signature, expected }) => {
   expect(parseSignature(signature)).toEqual(expected)
 })

--- a/packages/abitype/src/human-readable/runtime/utils.test.ts
+++ b/packages/abitype/src/human-readable/runtime/utils.test.ts
@@ -6,6 +6,11 @@ import {
   isSolidityType,
   isValidDataLocation,
   parseAbiParameter,
+  parseConstructorSignature,
+  parseErrorSignature,
+  parseEventSignature,
+  parseFallbackSignature,
+  parseFunctionSignature,
   parseSignature,
   splitParameters,
 } from './utils.js'
@@ -168,12 +173,56 @@ test('invalid signature', () => {
   )
 
   expect(() =>
-    parseSignature('method foo_(string)'),
+    parseFunctionSignature('function foo() invalid'),
   ).toThrowErrorMatchingInlineSnapshot(
     `
-    [UnknownSignatureError: Unknown signature.
+    [InvalidSignatureError: Invalid function signature.
 
-    Details: method foo_(string)
+    Details: function foo() invalid
+    Version: abitype@x.y.z]
+  `,
+  )
+
+  expect(() =>
+    parseEventSignature('event Foo(string memory foo) invalid'),
+  ).toThrowErrorMatchingInlineSnapshot(
+    `
+    [InvalidSignatureError: Invalid event signature.
+
+    Details: event Foo(string memory foo) invalid
+    Version: abitype@x.y.z]
+  `,
+  )
+
+  expect(() => {
+    parseErrorSignature('error Foo(string memory foo) invalid')
+  }).toThrowErrorMatchingInlineSnapshot(
+    `
+    [InvalidSignatureError: Invalid error signature.
+
+    Details: error Foo(string memory foo) invalid
+    Version: abitype@x.y.z]
+    `,
+  )
+
+  expect(() => {
+    parseConstructorSignature('constructor() invalid')
+  }).toThrowErrorMatchingInlineSnapshot(
+    `
+    [InvalidSignatureError: Invalid constructor signature.
+
+    Details: constructor() invalid
+    Version: abitype@x.y.z]
+    `,
+  )
+
+  expect(() => {
+    parseFallbackSignature('fallback() external invalid')
+  }).toThrowErrorMatchingInlineSnapshot(
+    `
+    [InvalidSignatureError: Invalid fallback signature.
+
+    Details: fallback() external invalid
     Version: abitype@x.y.z]
   `,
   )

--- a/packages/abitype/src/human-readable/runtime/utils.ts
+++ b/packages/abitype/src/human-readable/runtime/utils.ts
@@ -32,6 +32,7 @@ import {
   execConstructorSignature,
   execErrorSignature,
   execEventSignature,
+  execFallbackSignature,
   execFunctionSignature,
   functionModifiers,
   isConstructorSignature,
@@ -138,7 +139,16 @@ export function parseSignature(signature: string, structs: StructLookup = {}) {
     }
   }
 
-  if (isFallbackSignature(signature)) return { type: 'fallback' }
+  if (isFallbackSignature(signature)) {
+    const match = execFallbackSignature(signature)
+    if (!match) throw new InvalidSignatureError({ signature, type: 'fallback' })
+
+    return {
+      type: 'fallback',
+      stateMutability: match.stateMutability ?? 'nonpayable',
+    }
+  }
+
   if (isReceiveSignature(signature))
     return {
       type: 'receive',

--- a/packages/abitype/src/human-readable/runtime/utils.ts
+++ b/packages/abitype/src/human-readable/runtime/utils.ts
@@ -121,7 +121,7 @@ export function parseEventSignature(
   const params = splitParameters(match.parameters)
   const abiParameters = []
   const length = params.length
-  for (let i = 0; i < length; i++) {
+  for (let i = 0; i < length; i++)
     abiParameters.push(
       parseAbiParameter(params[i]!, {
         modifiers: eventModifiers,
@@ -129,7 +129,6 @@ export function parseEventSignature(
         type: 'event',
       }),
     )
-  }
   return { name: match.name, type: 'event', inputs: abiParameters }
 }
 
@@ -143,11 +142,10 @@ export function parseErrorSignature(
   const params = splitParameters(match.parameters)
   const abiParameters = []
   const length = params.length
-  for (let i = 0; i < length; i++) {
+  for (let i = 0; i < length; i++)
     abiParameters.push(
       parseAbiParameter(params[i]!, { structs, type: 'error' }),
     )
-  }
   return { name: match.name, type: 'error', inputs: abiParameters }
 }
 
@@ -162,11 +160,10 @@ export function parseConstructorSignature(
   const params = splitParameters(match.parameters)
   const abiParameters = []
   const length = params.length
-  for (let i = 0; i < length; i++) {
+  for (let i = 0; i < length; i++)
     abiParameters.push(
       parseAbiParameter(params[i]!, { structs, type: 'constructor' }),
     )
-  }
   return {
     type: 'constructor',
     stateMutability: match.stateMutability ?? 'nonpayable',

--- a/packages/abitype/src/human-readable/runtime/utils.ts
+++ b/packages/abitype/src/human-readable/runtime/utils.ts
@@ -43,6 +43,30 @@ import {
   isReceiveSignature,
 } from './signatures.js'
 
+export function parseSignature(signature: string, structs: StructLookup = {}) {
+  if (isFunctionSignature(signature))
+    return parseFunctionSignature(signature, structs)
+
+  if (isEventSignature(signature))
+    return parseEventSignature(signature, structs)
+
+  if (isErrorSignature(signature))
+    return parseErrorSignature(signature, structs)
+
+  if (isConstructorSignature(signature))
+    return parseConstructorSignature(signature, structs)
+
+  if (isFallbackSignature(signature)) return parseFallbackSignature(signature)
+
+  if (isReceiveSignature(signature))
+    return {
+      type: 'receive',
+      stateMutability: 'payable',
+    }
+
+  throw new UnknownSignatureError({ signature })
+}
+
 export function parseFunctionSignature(
   signature: string,
   structs: StructLookup = {},
@@ -158,36 +182,6 @@ export function parseFallbackSignature(signature: string) {
     type: 'fallback',
     stateMutability: match.stateMutability ?? 'nonpayable',
   }
-}
-
-export function parseSignature(signature: string, structs: StructLookup = {}) {
-  if (isFunctionSignature(signature)) {
-    return parseFunctionSignature(signature, structs)
-  }
-
-  if (isEventSignature(signature)) {
-    return parseEventSignature(signature, structs)
-  }
-
-  if (isErrorSignature(signature)) {
-    return parseErrorSignature(signature, structs)
-  }
-
-  if (isConstructorSignature(signature)) {
-    return parseConstructorSignature(signature, structs)
-  }
-
-  if (isFallbackSignature(signature)) {
-    return parseFallbackSignature(signature)
-  }
-
-  if (isReceiveSignature(signature))
-    return {
-      type: 'receive',
-      stateMutability: 'payable',
-    }
-
-  throw new UnknownSignatureError({ signature })
 }
 
 const abiParameterWithoutTupleRegex =

--- a/packages/abitype/src/human-readable/runtime/utils.ts
+++ b/packages/abitype/src/human-readable/runtime/utils.ts
@@ -43,110 +43,142 @@ import {
   isReceiveSignature,
 } from './signatures.js'
 
-export function parseSignature(signature: string, structs: StructLookup = {}) {
-  if (isFunctionSignature(signature)) {
-    const match = execFunctionSignature(signature)
-    if (!match) throw new InvalidSignatureError({ signature, type: 'function' })
+export function parseFunctionSignature(
+  signature: string,
+  structs: StructLookup = {},
+) {
+  const match = execFunctionSignature(signature)
+  if (!match) throw new InvalidSignatureError({ signature, type: 'function' })
 
-    const inputParams = splitParameters(match.parameters)
-    const inputs = []
-    const inputLength = inputParams.length
-    for (let i = 0; i < inputLength; i++) {
-      inputs.push(
-        parseAbiParameter(inputParams[i]!, {
+  const inputParams = splitParameters(match.parameters)
+  const inputs = []
+  const inputLength = inputParams.length
+  for (let i = 0; i < inputLength; i++) {
+    inputs.push(
+      parseAbiParameter(inputParams[i]!, {
+        modifiers: functionModifiers,
+        structs,
+        type: 'function',
+      }),
+    )
+  }
+
+  const outputs = []
+  if (match.returns) {
+    const outputParams = splitParameters(match.returns)
+    const outputLength = outputParams.length
+    for (let i = 0; i < outputLength; i++) {
+      outputs.push(
+        parseAbiParameter(outputParams[i]!, {
           modifiers: functionModifiers,
           structs,
           type: 'function',
         }),
       )
     }
+  }
 
-    const outputs = []
-    if (match.returns) {
-      const outputParams = splitParameters(match.returns)
-      const outputLength = outputParams.length
-      for (let i = 0; i < outputLength; i++) {
-        outputs.push(
-          parseAbiParameter(outputParams[i]!, {
-            modifiers: functionModifiers,
-            structs,
-            type: 'function',
-          }),
-        )
-      }
-    }
+  return {
+    name: match.name,
+    type: 'function',
+    stateMutability: match.stateMutability ?? 'nonpayable',
+    inputs,
+    outputs,
+  }
+}
 
-    return {
-      name: match.name,
-      type: 'function',
-      stateMutability: match.stateMutability ?? 'nonpayable',
-      inputs,
-      outputs,
-    }
+export function parseEventSignature(
+  signature: string,
+  structs: StructLookup = {},
+) {
+  const match = execEventSignature(signature)
+  if (!match) throw new InvalidSignatureError({ signature, type: 'event' })
+
+  const params = splitParameters(match.parameters)
+  const abiParameters = []
+  const length = params.length
+  for (let i = 0; i < length; i++) {
+    abiParameters.push(
+      parseAbiParameter(params[i]!, {
+        modifiers: eventModifiers,
+        structs,
+        type: 'event',
+      }),
+    )
+  }
+  return { name: match.name, type: 'event', inputs: abiParameters }
+}
+
+export function parseErrorSignature(
+  signature: string,
+  structs: StructLookup = {},
+) {
+  const match = execErrorSignature(signature)
+  if (!match) throw new InvalidSignatureError({ signature, type: 'error' })
+
+  const params = splitParameters(match.parameters)
+  const abiParameters = []
+  const length = params.length
+  for (let i = 0; i < length; i++) {
+    abiParameters.push(
+      parseAbiParameter(params[i]!, { structs, type: 'error' }),
+    )
+  }
+  return { name: match.name, type: 'error', inputs: abiParameters }
+}
+
+export function parseConstructorSignature(
+  signature: string,
+  structs: StructLookup = {},
+) {
+  const match = execConstructorSignature(signature)
+  if (!match)
+    throw new InvalidSignatureError({ signature, type: 'constructor' })
+
+  const params = splitParameters(match.parameters)
+  const abiParameters = []
+  const length = params.length
+  for (let i = 0; i < length; i++) {
+    abiParameters.push(
+      parseAbiParameter(params[i]!, { structs, type: 'constructor' }),
+    )
+  }
+  return {
+    type: 'constructor',
+    stateMutability: match.stateMutability ?? 'nonpayable',
+    inputs: abiParameters,
+  }
+}
+
+export function parseFallbackSignature(signature: string) {
+  const match = execFallbackSignature(signature)
+  if (!match) throw new InvalidSignatureError({ signature, type: 'fallback' })
+
+  return {
+    type: 'fallback',
+    stateMutability: match.stateMutability ?? 'nonpayable',
+  }
+}
+
+export function parseSignature(signature: string, structs: StructLookup = {}) {
+  if (isFunctionSignature(signature)) {
+    return parseFunctionSignature(signature, structs)
   }
 
   if (isEventSignature(signature)) {
-    const match = execEventSignature(signature)
-    if (!match) throw new InvalidSignatureError({ signature, type: 'event' })
-
-    const params = splitParameters(match.parameters)
-    const abiParameters = []
-    const length = params.length
-    for (let i = 0; i < length; i++) {
-      abiParameters.push(
-        parseAbiParameter(params[i]!, {
-          modifiers: eventModifiers,
-          structs,
-          type: 'event',
-        }),
-      )
-    }
-    return { name: match.name, type: 'event', inputs: abiParameters }
+    return parseEventSignature(signature, structs)
   }
 
   if (isErrorSignature(signature)) {
-    const match = execErrorSignature(signature)
-    if (!match) throw new InvalidSignatureError({ signature, type: 'error' })
-
-    const params = splitParameters(match.parameters)
-    const abiParameters = []
-    const length = params.length
-    for (let i = 0; i < length; i++) {
-      abiParameters.push(
-        parseAbiParameter(params[i]!, { structs, type: 'error' }),
-      )
-    }
-    return { name: match.name, type: 'error', inputs: abiParameters }
+    return parseErrorSignature(signature, structs)
   }
 
   if (isConstructorSignature(signature)) {
-    const match = execConstructorSignature(signature)
-    if (!match)
-      throw new InvalidSignatureError({ signature, type: 'constructor' })
-
-    const params = splitParameters(match.parameters)
-    const abiParameters = []
-    const length = params.length
-    for (let i = 0; i < length; i++) {
-      abiParameters.push(
-        parseAbiParameter(params[i]!, { structs, type: 'constructor' }),
-      )
-    }
-    return {
-      type: 'constructor',
-      stateMutability: match.stateMutability ?? 'nonpayable',
-      inputs: abiParameters,
-    }
+    return parseConstructorSignature(signature, structs)
   }
 
   if (isFallbackSignature(signature)) {
-    const match = execFallbackSignature(signature)
-    if (!match) throw new InvalidSignatureError({ signature, type: 'fallback' })
-
-    return {
-      type: 'fallback',
-      stateMutability: match.stateMutability ?? 'nonpayable',
-    }
+    return parseFallbackSignature(signature)
   }
 
   if (isReceiveSignature(signature))

--- a/packages/abitype/src/human-readable/types/signatures.test-d.ts
+++ b/packages/abitype/src/human-readable/types/signatures.test-d.ts
@@ -4,6 +4,7 @@ import type {
   IsConstructorSignature,
   IsErrorSignature,
   IsEventSignature,
+  IsFallbackSignature,
   IsFunctionSignature,
   IsName,
   IsSignature,
@@ -141,6 +142,15 @@ test('IsConstructorSignature', () => {
 
   assertType<IsConstructorSignature<'constructor()payable'>>(false)
   assertType<IsConstructorSignature<'constructor(string'>>(false)
+})
+
+test('IsFallbackSignature', () => {
+  assertType<IsFallbackSignature<'fallback() external'>>(true)
+  assertType<IsFallbackSignature<'fallback() external payable'>>(true)
+
+  assertType<IsFallbackSignature<'fallback() externalpayable'>>(false)
+  assertType<IsFallbackSignature<'fallback() external nonpayable'>>(false)
+  assertType<IsFallbackSignature<'fallback()'>>(false)
 })
 
 test('IsSignature', () => {

--- a/packages/abitype/src/human-readable/types/signatures.ts
+++ b/packages/abitype/src/human-readable/types/signatures.ts
@@ -72,7 +72,12 @@ type ValidConstructorSignatures =
   | `constructor(${string})`
   | `constructor(${string}) payable`
 
-export type FallbackSignature<abiStateMutability extends '' | ' payable' = ''> =
+export type IsFallbackSignature<signature extends string> = signature extends
+  | FallbackSignature<''>
+  | FallbackSignature<' payable'>
+  ? true
+  : false
+export type FallbackSignature<abiStateMutability extends '' | ' payable'> =
   `fallback() external${abiStateMutability}`
 
 export type ReceiveSignature = 'receive() external payable'
@@ -85,7 +90,7 @@ export type IsSignature<type extends string> =
   | (IsFunctionSignature<type> extends true ? true : never)
   | (IsStructSignature<type> extends true ? true : never)
   | (IsConstructorSignature<type> extends true ? true : never)
-  | (type extends FallbackSignature ? true : never)
+  | (IsFallbackSignature<type> extends true ? true : never)
   | (type extends ReceiveSignature ? true : never) extends infer condition
   ? [condition] extends [never]
     ? false

--- a/packages/abitype/src/human-readable/types/signatures.ts
+++ b/packages/abitype/src/human-readable/types/signatures.ts
@@ -72,13 +72,13 @@ type ValidConstructorSignatures =
   | `constructor(${string})`
   | `constructor(${string}) payable`
 
+export type FallbackSignature<abiStateMutability extends '' | ' payable'> =
+  `fallback() external${abiStateMutability}`
 export type IsFallbackSignature<signature extends string> = signature extends
   | FallbackSignature<''>
   | FallbackSignature<' payable'>
   ? true
   : false
-export type FallbackSignature<abiStateMutability extends '' | ' payable'> =
-  `fallback() external${abiStateMutability}`
 
 export type ReceiveSignature = 'receive() external payable'
 

--- a/packages/abitype/src/human-readable/types/signatures.ts
+++ b/packages/abitype/src/human-readable/types/signatures.ts
@@ -72,8 +72,9 @@ type ValidConstructorSignatures =
   | `constructor(${string})`
   | `constructor(${string}) payable`
 
-export type FallbackSignature<abiStateMutability extends '' | ' payable'> =
-  `fallback() external${abiStateMutability}`
+export type FallbackSignature<
+  abiStateMutability extends '' | ' payable' = '' | ' payable',
+> = `fallback() external${abiStateMutability}`
 export type IsFallbackSignature<signature extends string> = signature extends
   | FallbackSignature<''>
   | FallbackSignature<' payable'>


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts that require more attention from reviewers? -->
This is a follow-up for the issue https://github.com/wevm/abitype/pull/259, and finally fixes https://github.com/wevm/abitype/issues/253

* Fix how the parseAbiItem is parsing the fallback function. 
Before this PR `parseAbiItem('fallback() external payable')` would return type error
```
The argument of type '"fallback() external payable"' is not assignable to parameter of type '"fallback() external payable" & ["Error: Signature \"fallback() external payable\" is invalid."]'.
  Type 'string' is not assignable to type '["Error: Signature \"fallback() external payable\" is invalid."]'.ts(2345)
  ```
 Also, the actual values that were returned were incorrect, different from the returned type, and produced the following values
 `const abi = parseAbiItem('fallback() external payable') // abi equals to { type: 'fallback' }`
 `const abi = parseAbiItem('fallback() external') // abi equals to { type: 'fallback' }`


* Add integration tests that check whether formatAbiItem and parseAbitItem are reversible operations.

* Add more tests for a signature and parseAbiItem.

* refactor signature parsing, by extracting every signature case parsing so that the code can be tested, and code coverage step CI passes

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/abitype/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem similarly. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to ABIType!
----------------------------------------------------------------------->
