### PR TITLE
fix: address payable parsing

### DIFF
--- a/packages/abitype/src/human-readable/runtime/utils.test.ts
+++ b/packages/abitype/src/human-readable/runtime/utils.test.ts
@@ -57,6 +57,14 @@ test.each([
     },
   },
   {
+    signature: 'function foo(address payable to) external',
+    expected: {
+      ...baseFunctionExpected,
+      inputs: [{ type: 'address', name: 'to' }],
+      stateMutability: 'nonpayable',
+    },
+  },
+  {
     signature: 'function foo(string) public view returns (string)',
     expected: {
       ...baseFunctionExpected,

--- a/packages/abitype/src/human-readable/runtime/utils.ts
+++ b/packages/abitype/src/human-readable/runtime/utils.ts
@@ -182,7 +182,7 @@ export function parseFallbackSignature(signature: string) {
 }
 
 const abiParameterWithoutTupleRegex =
-  /^(?<type>[a-zA-Z$_][a-zA-Z0-9$_]*)(?<array>(?:\[\d*?\])+?)?(?:\s(?<modifier>calldata|indexed|memory|storage{1}))?(?:\s(?<name>[a-zA-Z$_][a-zA-Z0-9$_]*))?$/
+  /^(?<type>[a-zA-Z$_][a-zA-Z0-9$_]*(?:\spayable)?)(?<array>(?:\[\d*?\])+?)?(?:\s(?<modifier>calldata|indexed|memory|storage{1}))?(?:\s(?<name>[a-zA-Z$_][a-zA-Z0-9$_]*))?$/
 const abiParameterWithTupleRegex =
   /^\((?<type>.+?)\)(?<array>(?:\[\d*?\])+?)?(?:\s(?<modifier>calldata|indexed|memory|storage{1}))?(?:\s(?<name>[a-zA-Z$_][a-zA-Z0-9$_]*))?$/
 const dynamicIntegerRegex = /^u?int$/
@@ -238,6 +238,8 @@ export function parseAbiParameter(param: string, options?: ParseOptions) {
     components = { components: structs[match.type] }
   } else if (dynamicIntegerRegex.test(match.type)) {
     type = `${match.type}256`
+  } else if (match.type === 'address payable') {
+    type = 'address'
   } else {
     type = match.type
     if (!(options?.type === 'struct') && !isSolidityType(type))


### PR DESCRIPTION
Fixes #274 . This solves it by expanding the regex in `parseAbiParameter` to accept address payable as a solidity type and then later mapping it to `address` abi type.
