### PR TITLE
chore(deps): Add zod v4 support to peer dependencies

### DIFF
--- a/packages/abitype/package.json
+++ b/packages/abitype/package.json
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "typescript": ">=5.0.4",
-    "zod": "^3 >=3.22.0"
+    "zod": "^3.22.0 || ^4.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {


### PR DESCRIPTION
This PR updates the zod peer dependency range to support both 3.22.0+ and 4.0.0+ to resolve compatibility issues with projects using zod 4.

abitype does not use any breaking change listed in the [migration guide](https://zod.dev/v4/changelog) and is still fully compatible with only deprecation warnings.

I tried to update the dev dependency to use zod v4 and ran `build` without any errors 👍🏼 

<img width="1047" height="417" alt="Screenshot 2025-09-02 at 10 25 06 AM" src="https://github.com/user-attachments/assets/1192e568-3f7f-4bd9-9c69-146ed347e21b" />

**Kept dev dependency on zod 3 for testing purposes** - zod 4 introduces breaking changes in error format structure that would require updating snapshot tests

Fixes https://github.com/wevm/abitype/issues/273 and https://github.com/wevm/abitype/discussions/268
